### PR TITLE
feat(pvc): add support for creating PVC via chart

### DIFF
--- a/charts/apps/immich/templates/classes/_pvc.tpl
+++ b/charts/apps/immich/templates/classes/_pvc.tpl
@@ -1,0 +1,45 @@
+{{/*
+This template serves as a blueprint for all PersistentVolumeClaim objects that are created
+within the common library.
+*/}}
+{{- define "common.classes.pvc" -}}
+{{- $values := .Values.persistence -}}
+{{- if hasKey . "ObjectValues" -}}
+  {{- with .ObjectValues.persistence -}}
+    {{- $values = . -}}
+  {{- end -}}
+{{ end -}}
+{{- $pvcName := include "common.names.fullname" . -}}
+{{- if and (hasKey $values "nameOverride") $values.nameOverride -}}
+  {{- if not (eq $values.nameOverride "-") -}}
+    {{- $pvcName = printf "%v-%v" $pvcName $values.nameOverride -}}
+  {{ end -}}
+{{ end }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ $pvcName }}
+  {{- with (merge ($values.labels | default dict) (include "common.labels" $ | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    {{- if $values.retain }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    {{- with (merge ($values.annotations | default dict) (include "common.annotations" $ | fromYaml)) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+    - {{ required (printf "accessMode is required for PVC %v" $pvcName) $values.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ required (printf "size is required for PVC %v" $pvcName) $values.size | quote }}
+  {{- if $values.storageClass }}
+  storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else }}{{ $values.storageClass | quote }}{{- end }}
+  {{- end }}
+  {{- if $values.volumeName }}
+  volumeName: {{ $values.volumeName | quote }}
+  {{- end }}
+{{- end -}}

--- a/charts/apps/immich/templates/common.yaml
+++ b/charts/apps/immich/templates/common.yaml
@@ -10,4 +10,6 @@ global:
 {{ end }}
 
 {{- end -}}
+
+{{- include "common.pvc" . -}}
 {{- $_ := mergeOverwrite .Values (include "app-template.hardcodedValues" . | fromYaml) -}}

--- a/charts/apps/immich/templates/pvc.yaml
+++ b/charts/apps/immich/templates/pvc.yaml
@@ -1,0 +1,16 @@
+{{/*
+Renders the Persistent Volume Claim objects required by the chart.
+*/}}
+{{- define "common.pvc" -}}
+  {{- /* Generate pvc as required */ -}}
+  {{- range $index, $PVC := .Values.persistence }}
+    {{- if and $PVC.enabled (eq (default "pvc" $PVC.type) "pvc") (not $PVC.existingClaim) -}}
+      {{- $persistenceValues := $PVC -}}
+      {{- if not $persistenceValues.nameOverride -}}
+        {{- $_ := set $persistenceValues "nameOverride" $index -}}
+      {{- end -}}
+      {{- $_ := set $ "ObjectValues" (dict "persistence" $persistenceValues) -}}
+      {{- include "common.classes.pvc" $ | nindent 0 -}}
+    {{- end }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
This PR adds support for PVCs to be created via the chart

PVC created via the `persistence` key are also auto-mounted to every deployment