### PR TITLE
Upgrading redis chart to 17.11.6

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.1.1
+version: 0.1.2
 appVersion: v1.53.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg
@@ -25,7 +25,7 @@ dependencies:
   - name: redis
     condition: redis.enabled
     repository: https://charts.bitnami.com/bitnami
-    version: 17.1.4
+    version: 17.11.6
 annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-


### PR DESCRIPTION
This upgrade is mostly about updating the default image of redis used for deployment.

Helm chart version 17.1.4 defaults to image tag 7.0.4-debian-11-r17. There are a couple issues here. First, the latest version packaged by bitnami is 7.0.11, so there are some bug fixes, especially several security fixes, included in the newer version.

The other issue is that the older image tag is only uploaded for amd64 architectures. I run a hybrid cluster of amd64 and arm64, so I really need an image that's available to both.

The updated version (17.11.6) is the latest and defaults to image tag 7.0.11-debian-11-r20. This is both the newer version of redis (7.0.11) and the image is uploaded for both architectures.

Also, I bumped the chart version, but let me know if I should undo that for your release process.