### PR TITLE
Update postgresql dependency version to 12.6.9 to support arm64

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   - name: postgresql
     condition: postgresql.enabled
     repository: https://charts.bitnami.com/bitnami
-    version: 11.8.1
+    version: 12.6.9
   - name: redis
     condition: redis.enabled
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
The current version of postgresql `11.8.1` does not support `arm64`.
Updated to the latest version `12.6.9` to support `arm64`.