### PR TITLE
Update redis to 17.11.8

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   - name: redis
     condition: redis.enabled
     repository: https://charts.bitnami.com/bitnami
-    version: 17.11.6
+    version: 17.11.8
 annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-


### PR DESCRIPTION
I am using argocd to deploy immich and redis is continuously out of sync because of missing flags on their PVCs. This has been fixed upstream in a newer 17.11.X release.