### PR TITLE
Removing library mount from machine learning container

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.3.0
-appVersion: v1.91.0
+version: 0.3.1
+appVersion: v1.91.4
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg
 sources:
@@ -30,4 +30,4 @@ annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
     - kind: changed
-      description: Remove typesense, add pgvecto.rs
+      description: Removed unused library mount from machine learning container

--- a/charts/immich/templates/machine-learning.yaml
+++ b/charts/immich/templates/machine-learning.yaml
@@ -29,12 +29,6 @@ probes:
   readiness: *probes
   startup:
     enabled: false
-
-persistence:
-  library:
-    enabled: true
-    mountPath: /usr/src/app/upload
-    existingClaim: {{ .Values.immich.persistence.library.existingClaim }}
 {{- end }}
 
 {{- /* Have to reference with index here because the dash breaks a normal dereference */}}

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -14,7 +14,7 @@ env:
   IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
 
 image:
-  tag: v1.91.0
+  tag: v1.91.4
 
 immich:
   persistence:


### PR DESCRIPTION
The recommended docker-compose does not mount the library into the machine learning container. It seems like this isn't necessary (anymore?). Removing the mount.

I also went ahead and bumped to the latest patch while I was there.