### PR TITLE
Move to Bitnami Based Postgres Image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,41 @@ on:
       - main
 
 jobs:
+  # As the pgvecto-rs module is needed in the Immich Postgres, a custom Bitnami Image Build is implemented.
+  build-postgres:
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}/pg-bitnami-vecto-rs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Get bitnami tag
+        run: cd ./images/pgvecto-bitnami && ./bitnami-tag.sh >> $GITHUB_ENV
+      - name: Build and Push Versioned Docker Image
+        id: build-and-push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: ./images/pgvecto-bitnami/Dockerfile
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BITNAMI_TAG }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BITNAMI_TAG=${{ env.BITNAMI_TAG }}
   release:
+    needs: build-postgres
     permissions: write-all
     runs-on: ubuntu-latest
     steps:

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -30,7 +30,7 @@ postgresql:
   enabled: false
   image:
     registry: ghcr.io
-    repository: hofq/immich-charts/pg-bitnami-vecto-rs
+    repository: immich-app/immich-charts/pg-bitnami-vecto-rs
     tag: 14.5.0-debian-11-r6
   global:
     postgresql:

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -29,8 +29,9 @@ immich:
 postgresql:
   enabled: false
   image:
-    repository: tensorchord/pgvecto-rs
-    tag: pg14-v0.1.11
+    registry: ghcr.io
+    repository: hofq/immich-charts/pg-bitnami-vecto-rs
+    tag: 14.5.0-debian-11-r6
   global:
     postgresql:
       auth:

--- a/images/pgvecto-bitnami/Dockerfile
+++ b/images/pgvecto-bitnami/Dockerfile
@@ -1,0 +1,13 @@
+ARG PGVECTORS_TAG=pg14-v0.1.11-amd64
+ARG BITNAMI_TAG
+FROM scratch as nothing
+FROM tensorchord/pgvecto-rs-binary:${PGVECTORS_TAG} as binary
+
+FROM docker.io/bitnami/postgresql:${BITNAMI_TAG}
+COPY --from=binary /pgvecto-rs-binary-release.deb /tmp/vectors.deb
+USER root
+RUN apt-get install -y /tmp/vectors.deb && rm -f /tmp/vectors.deb && \
+     mv /usr/lib/postgresql/*/lib/vectors.so /opt/bitnami/postgresql/lib/ && \
+     mv usr/share/postgresql/*/extension/vectors* opt/bitnami/postgresql/share/extension/
+USER 1001
+ENV POSTGRESQL_EXTRA_FLAGS="-c shared_preload_libraries=vectors.so"

--- a/images/pgvecto-bitnami/bitnami-tag.sh
+++ b/images/pgvecto-bitnami/bitnami-tag.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+## This Script is intended to get Version Names from the Helm Chart to Build
+## a new Bitnami Image based of pgvector.rs
+
+# Get yq
+[ -f ./yq_linux_amd64 ] || curl -L https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_amd64 > yq_linux_amd64
+chmod +x yq_linux_amd64
+
+# Export Vars
+export BITNAMI_TAG=$(./yq_linux_amd64 '.postgresql.image.tag' ../../charts/immich/values.yaml)
+echo BITNAMI_TAG=$BITNAMI_TAG


### PR DESCRIPTION
Resolves #55

Currently, this chart uses the Bitnami PG subchart, which is made for the Bitnami PG Image. This Connectivity Allows for Easy Operation, as all in the Bitnami Chart Documented Functions also worked with the Immich Deployment.

Since the Change to pgvecto.rs in #53 and the related Image Change, this Compatibility no longer exists, which leads to some undocumented Breaks of Databases and Errors.


To restore features from that Bitnami Deployment, I added a pipeline based off @SoarinFerret `s [Dockerfile](https://github.com/SoarinFerret/bitnami-postgres-pgvecto-rs/blob/main/Dockerfile), which Builds an pgvecto.rs version of the Official Bitnami Image on Chart release, with the PG Version in the values.yaml file, and the pgvecto.rs version in the Dockerfile.

