### PR TITLE
Changes probes url its now with /api/

### DIFF
--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -24,7 +24,7 @@ probes:
     custom: true
     spec:
       httpGet:
-        path: /server-info/ping
+        path: /api/server-info/ping
         port: http
       initialDelaySeconds: 0
       periodSeconds: 10


### PR DESCRIPTION
Like in the demo server probe must change because  https://demo.immich.app/api/server-info/ping works but not  https://demo.immich.app/server-info/ping