### PR TITLE
chore(deps) bump jinja2 to 3.1.3

### DIFF
--- a/.ci/mkdocs/requirements.txt
+++ b/.ci/mkdocs/requirements.txt
@@ -3,3 +3,4 @@ mkdocs-macros-plugin ==0.7.0
 mkdocs-material ==8.4.2
 mkdocs-minify-plugin==0.5.0
 mkdocs-redirects==1.1.0
+jinja2==3.1.3


### PR DESCRIPTION
Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')

Jinja vulnerable to HTML attribute injection when passing user input as keys to xmlattr filter The `xmlattr` filter in affected versions of Jinja accepts keys containing spaces. XML/HTML attributes cannot contain spaces, as each would then be interpreted as a separate attribute. If an application accepts keys (as opposed to only values) as user input, and renders these in pages that other users see as well, an attacker could use this to inject other attributes and perform XSS. Note that accepting keys as user input is not common or a particularly intended use case of the `xmlattr` filter, and an application doing so should already be verifying what keys are provided regardless of this fix.

Bump jinja2 to 3.1.3, fixing CVE-2024-22195

