### PR TITLE
chore!: Bump postgresql major version to latest

### DIFF
--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -14,7 +14,7 @@ env:
   IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
 
 image:
-  tag: v1.95.1
+  tag: v1.100.0
 
 immich:
   persistence:
@@ -30,7 +30,7 @@ postgresql:
   enabled: false
   image:
     repository: tensorchord/pgvecto-rs
-    tag: pg14-v0.2.0
+    tag: pg16-v0.2.1
   global:
     postgresql:
       auth:


### PR DESCRIPTION
I can't find anywhere in the docs where it says the specific 2-3 year old postgresql 14 is required. I am running my setup with postgresql 16 and have not faced any issues, which is to be expected from one of the worlds most widely used SQL backends. I think bumping this should be completely safe. Bumped the immich tag too just to be absolutely sure.