### PR TITLE
feat: support server configuration as code (using immich-config.json)

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.5.0
+version: 0.6.0
 appVersion: v1.100.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/templates/immich-config.yml
+++ b/charts/immich/templates/immich-config.yml
@@ -1,0 +1,15 @@
+{{- if .Values.immich.configuration }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-immich-config
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+data:
+  immich-config.yaml: |
+{{- .Values.immich.configuration | toYaml | nindent 4 }}
+{{- end }}

--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -14,6 +14,11 @@ env:
       IMMICH_CONFIG_FILE: /config/immich-config.yaml
   {{- end }}
 
+{{- if .Values.immich.configuration }}
+podAnnotations:
+  checksum/config: {{ .Values.immich.configuration | toYaml | sha256sum }}
+{{- end }}
+
 service:
   main:
     enabled: {{ .Values.immich.metrics.enabled }}
@@ -36,23 +41,12 @@ serviceMonitor:
       - port: metrics
         scheme: http
 
-{{- if .Values.immich.configuration }}
-configMaps:
-  config:
-    enabled: true
-    labels: {}
-    annotations: {}
-    data:
-      immich-config.yaml: |
-{{- .Values.immich.configuration | toYaml | nindent 8 }}
-{{- end }}
-
 persistence:
 {{- if .Values.immich.configuration }}
   config:
     enabled: true
     type: configMap
-    name: {{ .Release.Name }}-microservices-config
+    name: {{ .Release.Name }}-immich-config
 {{- end }}
   library:
     enabled: true

--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -10,6 +10,9 @@ env:
   {{ if .Values.immich.metrics.enabled }}
       IMMICH_METRICS: true
   {{ end }}
+  {{- if .Values.immich.configuration }}
+      IMMICH_CONFIG_FILE: /config/immich-config.yaml
+  {{- end }}
 
 service:
   main:
@@ -33,7 +36,24 @@ serviceMonitor:
       - port: metrics
         scheme: http
 
+{{- if .Values.immich.configuration }}
+configMaps:
+  config:
+    enabled: true
+    labels: {}
+    annotations: {}
+    data:
+      immich-config.yaml: |
+{{- .Values.immich.configuration | toYaml | nindent 8 }}
+{{- end }}
+
 persistence:
+{{- if .Values.immich.configuration }}
+  config:
+    enabled: true
+    type: configMap
+    name: {{ .Release.Name }}-microservices-config
+{{- end }}
   library:
     enabled: true
     mountPath: /usr/src/app/upload

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -11,7 +11,7 @@ env:
       IMMICH_METRICS: true
   {{ end }}
   {{- if .Values.immich.configuration }}
-      IMMICH_CONFIG_FILE: /config/immich-config.json
+      IMMICH_CONFIG_FILE: /config/immich-config.yaml
   {{- end }}
 
 service:
@@ -60,8 +60,8 @@ configMaps:
     labels: {}
     annotations: {}
     data:
-      immich-config.json: |
-{{- .Values.immich.configuration | toJson | nindent 8 }}
+      immich-config.yaml: |
+{{- .Values.immich.configuration | toYaml | nindent 8 }}
 {{- end }}
 
 persistence:

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -34,7 +34,26 @@ probes:
   startup:
     enabled: false
 
+{{- if .Values.immich.configuration }}
+env:
+  IMMICH_CONFIG_FILE: /config/immich-config.json
+configMaps:
+  config:
+    enabled: true
+    labels: {}
+    annotations: {}
+    data:
+      immich-config.json: |
+{{- .Values.immich.configuration | toJson | nindent 8 }}
+{{- end }}
+
 persistence:
+{{- if .Values.immich.configuration }}
+  config:
+    enabled: true
+    type: configMap
+    name: {{ .Release.Name }}-server-config
+{{- end }}
   library:
     enabled: true
     mountPath: /usr/src/app/upload

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -14,6 +14,11 @@ env:
       IMMICH_CONFIG_FILE: /config/immich-config.yaml
   {{- end }}
 
+{{- if .Values.immich.configuration }}
+podAnnotations:
+  checksum/config: {{ .Values.immich.configuration | toYaml | sha256sum }}
+{{- end }}
+
 service:
   main:
     enabled: true
@@ -53,23 +58,12 @@ probes:
   startup:
     enabled: false
 
-{{- if .Values.immich.configuration }}
-configMaps:
-  config:
-    enabled: true
-    labels: {}
-    annotations: {}
-    data:
-      immich-config.yaml: |
-{{- .Values.immich.configuration | toYaml | nindent 8 }}
-{{- end }}
-
 persistence:
 {{- if .Values.immich.configuration }}
   config:
     enabled: true
     type: configMap
-    name: {{ .Release.Name }}-server-config
+    name: {{ .Release.Name }}-immich-config
 {{- end }}
   library:
     enabled: true

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -10,6 +10,9 @@ env:
   {{ if .Values.immich.metrics.enabled }}
       IMMICH_METRICS: true
   {{ end }}
+  {{- if .Values.immich.configuration }}
+      IMMICH_CONFIG_FILE: /config/immich-config.json
+  {{- end }}
 
 service:
   main:
@@ -51,8 +54,6 @@ probes:
     enabled: false
 
 {{- if .Values.immich.configuration }}
-env:
-  IMMICH_CONFIG_FILE: /config/immich-config.json
 configMaps:
   config:
     enabled: true

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -27,6 +27,7 @@ immich:
       # You have to specify an existing PVC to use
       existingClaim:
   # configuration is immich-config.json converted to yaml
+  # ref: https://immich.app/docs/install/config-file/
   # If not provided or empty configuration can be changed from UI
   # {
   #   "trash": {

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -29,17 +29,13 @@ immich:
   # configuration is immich-config.json converted to yaml
   # ref: https://immich.app/docs/install/config-file/
   #
-  # WARNING: for storageTemplate->template it contains `{{` and `}}` which interferes with templating
-  # wrap value in "{{`<value>`}}"
-  # for more examples see PR https://github.com/immich-app/immich-charts/pull/76
-  #
   configuration: {}
     # trash:
     #   enabled: false
     #   days: 30
     # storageTemplate:
     #   enabled: true
-    #   template: "{{`{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}`}}"
+    #   template: "{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}"
 
 # Dependencies
 

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -23,6 +23,19 @@ immich:
       # Automatically creating the library volume is not supported by this chart
       # You have to specify an existing PVC to use
       existingClaim:
+  # configuration is immich-config.json converted to yaml
+  # If not provided or empty configuration can be changed from UI
+  # {
+  #   "trash": {
+  #     "enabled": true,
+  #     "days": 30
+  #   }
+  # }
+  # can be provided as example below
+  configuration: {}
+    # trash:
+    #   enabled: true
+    #   days: 30
 
 # Dependencies
 

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -30,31 +30,16 @@ immich:
   # ref: https://immich.app/docs/install/config-file/
   #
   # WARNING: for storageTemplate->template it contains `{{` and `}}` which interferes with templating
-  # replace All : {{ with {{`{{`}}  AND  }} with {{`{{`}}
+  # wrap value in "{{`<value>`}}"
   # for more examples see PR https://github.com/immich-app/immich-charts/pull/76
-  # 
-  # If not provided or empty, configuration can be changed from UI
-  #
-  # {
-  #   "trash": {
-  #     "enabled": true,
-  #     "days": 30
-  #   },
-  #   "storageTemplate": {
-  #     "enabled": true
-  #     "template": "{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}"
-  #   }
-  # }
-  # can be provided as example below.
   #
   configuration: {}
-    # Example 
     # trash:
     #   enabled: false
     #   days: 30
     # storageTemplate:
     #   enabled: true
-    #   template: "{{`{{`}}y{{`}}`}}-{{`{{`}}MM{{`}}`}}-{{`{{`}}dd{{`}}`}}/{{`{{`}}filename{{`}}`}}"
+    #   template: "{{`{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}`}}"
 
 # Dependencies
 

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -28,18 +28,33 @@ immich:
       existingClaim:
   # configuration is immich-config.json converted to yaml
   # ref: https://immich.app/docs/install/config-file/
-  # If not provided or empty configuration can be changed from UI
+  #
+  # WARNING: for storageTemplate->template it contains `{{` and `}}` which interferes with templating
+  # replace All : {{ with {{`{{`}}  AND  }} with {{`{{`}}
+  # for more examples see PR https://github.com/immich-app/immich-charts/pull/76
+  # 
+  # If not provided or empty, configuration can be changed from UI
+  #
   # {
   #   "trash": {
   #     "enabled": true,
   #     "days": 30
+  #   },
+  #   "storageTemplate": {
+  #     "enabled": true
+  #     "template": "{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}"
   #   }
   # }
-  # can be provided as example below
+  # can be provided as example below.
+  #
   configuration: {}
+    # Example 
     # trash:
-    #   enabled: true
+    #   enabled: false
     #   days: 30
+    # storageTemplate:
+    #   enabled: true
+    #   template: "{{`{{`}}y{{`}}`}}-{{`{{`}}MM{{`}}`}}-{{`{{`}}dd{{`}}`}}/{{`{{`}}filename{{`}}`}}"
 
 # Dependencies
 


### PR DESCRIPTION
### Description of the change

Support configuration of immich settings using helm chart.

values.yaml example

```
...
immich:
  configuration: 
    trash:
      enabled: true
      days: 30
...
```

<!-- Describe any known limitations with your change -->

### Applicable issues

  - fixes #72 

### Open Point

No open points

### Use cases

- If `configuration:` or `configuration: {}` no changes to original behaviour or additional resources created and settings can be changed from UI.
- If valid values provided a ConfigMap `release-name-immich-config` will be created and mounted on `server` and `microservices` pod
  with new env variable `IMMICH_CONFIG_FILE: /config/immich-config.yaml` . No settings can be changed from UI after configuration.
