### PR TITLE
fix(servicemonitor): patch metrics labels to prefix with immich_

### DIFF
--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -40,6 +40,11 @@ serviceMonitor:
     endpoints:
       - port: metrics
         scheme: http
+        metricRelabelings:
+          - sourceLabels: [__name__]
+            targetLabel: __name__
+            regex: '(.*)'
+            replacement: "immich_$1"
 
 persistence:
 {{- if .Values.immich.configuration }}

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -41,6 +41,11 @@ serviceMonitor:
     endpoints:
       - port: metrics
         scheme: http
+        metricRelabelings:
+          - sourceLabels: [__name__]
+            targetLabel: __name__
+            regex: '(.*)'
+            replacement: "immich_$1"
 
 probes:
   liveness: &probes


### PR DESCRIPTION
### Description of the change

Add  `immich_` prefix to metrics labels as per discussion https://github.com/immich-app/immich/discussions/8191#discussioncomment-9043115

Should be reverted when https://github.com/pragmaticivan/nestjs-otel/issues/265 is fixed

### Applicable issues

  - fixes #82 
