### PR TITLE
feat: support custom nameOverride for components

### DIFF
--- a/charts/immich/templates/machine-learning.yaml
+++ b/charts/immich/templates/machine-learning.yaml
@@ -1,6 +1,6 @@
 {{- define "immich.machine-learning.hardcodedValues" -}}
 global:
-  nameOverride: machine-learning
+  nameOverride: {{ .Values.server.nameOverride | default "machine-learning" | quote }}
 
 service:
   main:

--- a/charts/immich/templates/machine-learning.yaml
+++ b/charts/immich/templates/machine-learning.yaml
@@ -1,6 +1,6 @@
 {{- define "immich.machine-learning.hardcodedValues" -}}
 global:
-  nameOverride: {{ .Values.server.nameOverride | default "machine-learning" | quote }}
+  nameOverride: {{ (index .Values "machine-learning").nameOverride | default "machine-learning" | quote }}
 
 service:
   main:

--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -1,6 +1,6 @@
 {{- define "immich.microservices.hardcodedValues" -}}
 global:
-  nameOverride: {{ .Values.server.nameOverride | default "microservices" | quote }}
+  nameOverride: {{ .Values.microservices.nameOverride | default "microservices" | quote }}
 
 command: "/bin/sh"
 args:

--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -1,6 +1,6 @@
 {{- define "immich.microservices.hardcodedValues" -}}
 global:
-  nameOverride: microservices
+  nameOverride: {{ .Values.server.nameOverride | default "microservices" | quote }}
 
 command: "/bin/sh"
 args:

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -1,6 +1,6 @@
 {{- define "immich.server.hardcodedValues" -}}
 global:
-  nameOverride: server
+  nameOverride: {{ .Values.server.nameOverride | default "server" | quote }}
 
 command: "/bin/sh"
 args:

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -68,6 +68,7 @@ redis:
 
 server:
   enabled: true
+  nameOverride: ''
   image:
     repository: ghcr.io/immich-app/immich-server
     pullPolicy: IfNotPresent
@@ -85,12 +86,14 @@ server:
 
 microservices:
   enabled: true
+  nameOverride: ''
   image:
     repository: ghcr.io/immich-app/immich-server
     pullPolicy: IfNotPresent
 
 machine-learning:
   enabled: true
+  nameOverride: ''
   image:
     repository: ghcr.io/immich-app/immich-machine-learning
     pullPolicy: IfNotPresent


### PR DESCRIPTION
### Problem

the default nameOverride of all components are not changable. This may cause maintenance issues when multiple apps are combined in a super chart. For instance, a release named 'release' which includes immich and another app may have the following workloads:

- deployment/release-server (immich server)
- deployment/release-app-server (server of another app)

By looking at the names it is hard to tell which app the `release-server` deployment belongs to. It could even cause name conflict if the other app has decided to use the same assumption on the nameOverride.

### Solution

Each component now receives a value called 'nameOverride', so that the name of workloads can be customized according to the end user's requirements.

### Alternatives/Workarounds

There is not workaround I could imagine. On the other hand there exists many other ways to solve the problem. One of them is as follows:

```yaml
# values.yaml
name: 'immich'

# server.yaml
global:
  # example name: release-immich-server
  nameOverride: {{ printf "%s-%s" .Values.name "server" | quote }}
```

Considering backward compatibility, it may cause breaking change on upgrades.