### PR TITLE
Update redis chart to avoid issues with ARM

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   - name: redis
     condition: redis.enabled
     repository: https://charts.bitnami.com/bitnami
-    version: 18.4.0
+    version: 19.5.3
 annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.7.0
+version: 0.7.1
 appVersion: v1.106.1
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg


### PR DESCRIPTION
Hey there!

I was running the helm for my raspberry but when it tried to deploy redis it fails with the following error:
```bash
│ <jemalloc>: Unsupported system page size   
│ <jemalloc>: Unsupported system page size                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
```

After I bumped the redis chart version it worked:

```bash
│ 1:C 14 Jun 2024 11:50:56.448 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo                                                              │
│ 1:C 14 Jun 2024 11:50:56.448 * Redis version=7.2.5, bits=64, commit=00000000, modified=0, pid=1, just started                             ││ 1:C 14 Jun 2024 11:50:56.448 * Configuration loaded                                                                                       ││ 1:M 14 Jun 2024 11:50:56.448 * monotonic clock: POSIX clock_gettime                                                                       │
│ 1:M 14 Jun 2024 11:50:56.449 * Running mode=standalone, port=6379.                                                                        ││ 1:M 14 Jun 2024 11:50:56.449 * Server initialized                                                                                         ││ 1:M 14 Jun 2024 11:50:56.452 * Reading RDB base file on AOF loading...                                                                    │
│ 1:M 14 Jun 2024 11:50:56.452 * Loading RDB produced by version 7.2.5                                                                      ││ 1:M 14 Jun 2024 11:50:56.452 * RDB age 59 seconds                                                                                         ││ 1:M 14 Jun 2024 11:50:56.452 * RDB memory usage when created 0.86 Mb                                                                      │
│ 1:M 14 Jun 2024 11:50:56.452 * RDB is base AOF                                                                                            ││ 1:M 14 Jun 2024 11:50:56.452 * Done loading RDB, keys loaded: 0, keys expired: 0.                                                         ││ 1:M 14 Jun 2024 11:50:56.536 * DB loaded from base file appendonly.aof.1.base.rdb: 0.085 seconds                                          │
│ 1:M 14 Jun 2024 11:50:56.536 * DB loaded from append only file: 0.085 seconds                                                             ││ 1:M 14 Jun 2024 11:50:56.536 * Opening AOF incr file appendonly.aof.1.incr.aof on server start                                            ││ 1:M 14 Jun 2024 11:50:56.536 * Ready to accept connections tcp                                                                            │
│ Stream closed EOF for immich/immich-redis-master-0 (redis)
```