### PR TITLE
Support for separate workers

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.7.0
+version: 0.8.0
 appVersion: v1.106.1
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -1,0 +1,59 @@
+{{- define "immich.microservices.hardcodedValues" -}}
+global:
+  nameOverride: microservices
+
+env:
+      IMMICH_WORKERS_INCLUDE: microservices
+  {{- if .Values.immich.metrics.enabled }}
+      IMMICH_METRICS: true
+  {{- end }}
+  {{- if .Values.immich.configuration }}
+      IMMICH_CONFIG_FILE: /config/immich-config.yaml
+  {{- end }}
+
+{{- if .Values.immich.configuration }}
+podAnnotations:
+  checksum/config: {{ .Values.immich.configuration | toYaml | sha256sum }}
+{{- end }}
+
+service:
+  main:
+    enabled: {{ .Values.immich.metrics.enabled }}
+    type: ClusterIP
+    ports:
+      http:
+        enabled: false
+        primary: true
+        port: 3001
+        protocol: HTTP
+      metrics:
+        enabled: {{ .Values.immich.metrics.enabled }}
+        port: 8082
+        protocol: HTTP
+
+serviceMonitor:
+  main:
+    enabled: {{ .Values.immich.metrics.enabled }}
+    endpoints:
+      - port: metrics
+        scheme: http
+
+persistence:
+{{- if .Values.immich.configuration }}
+  config:
+    enabled: true
+    type: configMap
+    name: {{ .Release.Name }}-immich-config
+{{- end }}
+  library:
+    enabled: true
+    mountPath: /usr/src/app/upload
+    existingClaim: {{ .Values.immich.persistence.library.existingClaim }}
+{{- end }}
+
+{{ if .Values.microservices.enabled }}
+{{- $ctx := deepCopy . -}}
+{{- $_ := get .Values "microservices" | mergeOverwrite $ctx.Values -}}
+{{- $_ = include "immich.microservices.hardcodedValues" . | fromYaml | merge $ctx.Values -}}
+{{- include "bjw-s.common.loader.all" $ctx }}
+{{ end }}

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -9,6 +9,9 @@ env:
   {{- if .Values.immich.configuration }}
       IMMICH_CONFIG_FILE: /config/immich-config.yaml
   {{- end }}
+  {{- if .Values.microservices.enabled }}
+      IMMICH_WORKERS_EXCLUDE: microservices
+  {{- end }}
 
 {{- if .Values.immich.configuration }}
 podAnnotations:
@@ -31,7 +34,7 @@ service:
         port: 8081
         protocol: HTTP
       metrics-ms:
-        enabled: {{ .Values.immich.metrics.enabled }}
+        enabled: {{ and .Values.immich.metrics.enabled ( not .Values.microservices.enabled ) }}
         port: 8082
         protocol: HTTP
 
@@ -42,8 +45,10 @@ serviceMonitor:
     endpoints:
       - port: metrics-api
         scheme: http
+{{- if not .Values.microservices.enabled}}
       - port: metrics-ms
         scheme: http
+{{- end }}
 
 probes:
   liveness: &probes

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -83,6 +83,15 @@ server:
             - path: "/"
       tls: []
 
+microservices:
+  # setting this will split api and microservices workers, by disabling
+  # microservices in the main server and launching separate deployment for
+  # microservices
+  enabled: false
+  image:
+    repository: ghcr.io/immich-app/immich-server
+    pullPolicy: IfNotPresent
+
 machine-learning:
   enabled: true
   image:


### PR DESCRIPTION
This PR enables running microservices in a separate container again.

With defaults, this should render the same as in previous version `v0.7.0`.

When `.Values.microservices.enable` is set to `true`:
- separate microservices deployment will be created, with `IMMICH_WORKERS_INCLUDE` variable set to `microservices`
- default api server deployment will have environment variable `IMMICH_WOKERS_EXCLUDE` set to `microservices`
- if `.Values.immich.metrics.enabled` is true, the microservices metrics port and relevant `serviceMonitor` port will only be exposed on main api server if separate microservices deployment is disabled - otherwise it will be exposed in its own service

fixes #94 