### PR TITLE
Extra volume for external libraries

### DIFF
--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -72,6 +72,10 @@ persistence:
     enabled: true
     mountPath: /usr/src/app/upload
     existingClaim: {{ .Values.immich.persistence.library.existingClaim }}
+  extraVolume:
+    enabled: {{ .Values.immich.persistence.extraVolume.enabled }}
+    mountPath: /usr/src/app/existing-library
+    existingClaim: {{ .Values.immich.persistence.extraVolume.existingClaim }}
 {{- end }}
 
 {{ if .Values.server.enabled }}

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -26,6 +26,12 @@ immich:
       # Automatically creating the library volume is not supported by this chart
       # You have to specify an existing PVC to use
       existingClaim:
+      # Extra Storage for External Libraries. This needs to be pre-created and available.
+    # You can then add /usr/src/app/existing-library in Existing Libraries in the UI.
+    extraVolume:
+      enabled: false
+      # existingClaim: 
+  
   # configuration is immich-config.json converted to yaml
   # ref: https://immich.app/docs/install/config-file/
   #


### PR DESCRIPTION
This will give users the ability to add an extra volume as a PVC which can then be configured in External Libraries in the UI.

I have tested this in my own deployment and works well.