### PR TITLE
feat: support subPath for library

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.7.2
+version: 0.7.3
 appVersion: v1.106.1
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -81,7 +81,7 @@ persistence:
     enabled: true
     mountPath: /usr/src/app/upload
     existingClaim: {{ .Values.immich.persistence.library.existingClaim }}
-    subPath: {{ .Values.immich.persistence.library.subPath }}
+    {{- toYaml .Values.immich.persistence.library | nindent 4 }}
 {{- end }}
 
 {{ if .Values.server.enabled }}

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -81,6 +81,7 @@ persistence:
     enabled: true
     mountPath: /usr/src/app/upload
     existingClaim: {{ .Values.immich.persistence.library.existingClaim }}
+    subPath: {{ .Values.immich.persistence.library.subPath }}
 {{- end }}
 
 {{ if .Values.server.enabled }}

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -26,9 +26,6 @@ immich:
       # Automatically creating the library volume is not supported by this chart
       # You have to specify an existing PVC to use
       existingClaim:
-      # Used in conjunction with `existingClaim`. Specifies a sub-path inside the referenced volume instead of its root
-      # Useful when you want to use one PV for multiple services
-      subPath: ""
   # configuration is immich-config.json converted to yaml
   # ref: https://immich.app/docs/install/config-file/
   #

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -26,6 +26,9 @@ immich:
       # Automatically creating the library volume is not supported by this chart
       # You have to specify an existing PVC to use
       existingClaim:
+      # Used in conjunction with `existingClaim`. Specifies a sub-path inside the referenced volume instead of its root
+      # Useful when you want to use one PV for multiple services
+      subPath: ""
   # configuration is immich-config.json converted to yaml
   # ref: https://immich.app/docs/install/config-file/
   #


### PR DESCRIPTION
It will be handy if we can set subPath in library config so we don't have to create and manage separate pv for library/machine-learning-models/postgre/redis.

It allows us to do something like this:

```yaml
image:
  tag: v1.113.0

immich:
  metrics:
    enabled: false
  persistence:
    library:
      existingClaim: immich
      subPath: data

machine-learning:
  persistence:
    cache:
      enabled: true
      type: null # Have to set this to null otherwise emptyDir will be used.
      path: /cache
      existingClaim: immich
      subPath: ml-model-cache

postgresql:
  enabled: true
  primary:
    persistence:
      existingClaim: immich
      subPath: postgresql

redis:
  enabled: true
  auth:
    enabled: false
  master:
    persistence:
      existingClaim: immich
      subPath: redis
```