### PR TITLE
chore: bump bitnami/postgresql dependency version

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.7.2
+version: 0.8.0
 appVersion: v1.106.1
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   - name: postgresql
     condition: postgresql.enabled
     repository: https://charts.bitnami.com/bitnami
-    version: 13.2.24
+    version: 16.0.0
   - name: redis
     condition: redis.enabled
     repository: https://charts.bitnami.com/bitnami

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -51,7 +51,7 @@ probes:
     custom: true
     spec:
       httpGet:
-        path: /api/server-info/ping
+        path: /api/server/ping
         port: http
       initialDelaySeconds: 0
       periodSeconds: 10
@@ -63,7 +63,7 @@ probes:
     custom: true
     spec:
       httpGet:
-        path: /api/server-info/ping
+        path: /api/server/ping
         port: http
       initialDelaySeconds: 0
       periodSeconds: 10


### PR DESCRIPTION
I came across a new feature in the chart that I needed, added in 15.1.3 (https://github.com/bitnami/charts/pull/23979), basically lets me mount a custom backup script into the backup container. I think this is useful in immich because it is recommended to backup the database with `pg_dumpall` (https://immich.app/docs/administration/backup-and-restore/#database), and the bitnami chart lets me do this quite elegantly.

Figured we might as well bump to the latest version seeing our use of the chart is rather simple and nothing breaks in our usage. For good measure I've bumped the chart version too because bumping a major version of a dependency is a breaking change for the dependent too I guess?

Let me know what you think.