### PR TITLE
Upgrade common chart. Allow split api/worker config.

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.8.2
+version: 0.9.0
 appVersion: v1.118.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg
@@ -17,7 +17,7 @@ maintainers:
 dependencies:
   - name: common
     repository: https://bjw-s.github.io/helm-charts
-    version: 1.4.0
+    version: 3.5.1
   - name: postgresql
     condition: postgresql.enabled
     repository: https://charts.bitnami.com/bitnami

--- a/charts/immich/templates/_utils/debug.tpl
+++ b/charts/immich/templates/_utils/debug.tpl
@@ -1,0 +1,3 @@
+{{- define "debug.var_dump" -}}
+{{- . | toPrettyJson | printf "\nThe JSON output of the dumped var is: \n%s" | fail }}
+{{- end -}}

--- a/charts/immich/templates/checks.yaml
+++ b/charts/immich/templates/checks.yaml
@@ -1,1 +1,4 @@
 {{- $name := .Values.immich.persistence.library.existingClaim | required ".Values.immich.persistence.library.existingClaim is required." -}}
+{{- if and (eq .Values.workers.enabled true) (eq .Values.workers.enabled .Values.server.enabled) }}
+{{- fail (printf "Only one of workers.enabled or server.enabled must be true.") }}
+{{- end }}

--- a/charts/immich/templates/machine-learning.yaml
+++ b/charts/immich/templates/machine-learning.yaml
@@ -2,10 +2,21 @@
 global:
   nameOverride: machine-learning
 
+controllers:
+  machine-learning:
+    containers:
+      main:
+        enabled: true
+        image:
+          repository: ghcr.io/immich-app/immich-machine-learning
+          pullPolicy: IfNotPresent
+          tag: {{ .Values.immich.image.tag }}
+
 service:
-  main:
+  machine-learning:
     enabled: true
     primary: true
+    controller: machine-learning
     type: ClusterIP
     ports:
       http:
@@ -29,12 +40,13 @@ probes:
   readiness: *probes
   startup:
     enabled: false
+# end of define
 {{- end }}
 
 {{- /* Have to reference with index here because the dash breaks a normal dereference */}}
 {{ if (index .Values "machine-learning").enabled }}
-{{- $ctx := deepCopy . -}}
-{{- $_ := get .Values "machine-learning" | mergeOverwrite $ctx.Values -}}
-{{- $_ = include "immich.machine-learning.hardcodedValues" . | fromYaml | merge $ctx.Values -}}
+{{- $ctx := deepCopy (omit . "Values") }}
+{{- $_ := set $ctx "Values" dict }}
+{{- $_ := merge $ctx.Values (deepCopy .Values.common) (include "immich.machine-learning.hardcodedValues" . | fromYaml) (deepCopy (get .Values "machine-learning")) -}}
 {{- include "bjw-s.common.loader.all" $ctx }}
-{{ end }}
+{{- end }}

--- a/charts/immich/templates/workers.yaml
+++ b/charts/immich/templates/workers.yaml
@@ -1,6 +1,25 @@
-{{- define "immich.server.hardcodedValues" -}}
+
+{{- define "immich.workers.hardcodedValues" -}}
 global:
-  nameOverride: server
+  nameOverride: workers
+
+env:
+  {{ if .Values.immich.metrics.enabled }}
+      IMMICH_METRICS: true
+  {{ end }}
+  {{- if .Values.immich.configuration }}
+      IMMICH_CONFIG_FILE: /config/immich-config.yaml
+  {{- end }}
+
+{{- $worker_env := deepCopy .Values.immich.env }}
+{{ if .Values.immich.metrics.enabled }}
+{{- $_ := merge $worker_env (dict "IMMICH_METRICS" "true") }}
+{{- end }}
+{{ if .Values.immich.configuration }}
+{{- $_ := merge $worker_env (dict "IMMICH_CONFIG_FILE" "/config/immich-config.yaml") }}
+{{- end }}
+{{- $apiEnv := merge (deepCopy $worker_env) (dict "IMMICH_WORKERS_INCLUDE" "api")}}
+{{- $microservicesEnv := merge (deepCopy $worker_env) (dict "IMMICH_WORKERS_EXCLUDE" "api")}}
 
 {{- if .Values.immich.configuration }}
 defaultPodOptions:
@@ -9,7 +28,8 @@ defaultPodOptions:
 {{- end }}
 
 controllers:
-  immich-server:
+  api:
+    enabled: true
     containers:
       main:
         enabled: true
@@ -17,19 +37,23 @@ controllers:
           repository: ghcr.io/immich-app/immich-server
           pullPolicy: IfNotPresent
           tag: {{ .Values.immich.image.tag }}
-        env:
-          {{ if .Values.immich.metrics.enabled }}
-              IMMICH_METRICS: true
-          {{ end }}
-          {{- if .Values.immich.configuration }}
-              IMMICH_CONFIG_FILE: /config/immich-config.yaml
-          {{- end }}
-
+        env: {{ $apiEnv | toYaml | nindent 10 }}
+  microservices:
+    enabled: true
+    containers:
+      main:
+        enabled: true
+        image:
+          repository: ghcr.io/immich-app/immich-server
+          pullPolicy: IfNotPresent
+          tag: {{ .Values.immich.image.tag }}
+        env: {{ $microservicesEnv | toYaml | nindent 10 }}
 service:
-  immich-server:
+  api:
     enabled: true
     primary: true
-    controller: immich-server
+    controller: api
+    nameOverride: api
     type: ClusterIP
     ports:
       http:
@@ -41,19 +65,31 @@ service:
         enabled: {{ .Values.immich.metrics.enabled }}
         port: 8081
         protocol: HTTP
+{{- if .Values.immich.metrics.enabled }}
+  microservices:
+    enabled: true
+    primary: true
+    controller: microservices
+    nameOverride: microservices
+    type: ClusterIP
+    ports:
       metrics-ms:
         enabled: {{ .Values.immich.metrics.enabled }}
         port: 8082
         protocol: HTTP
-
+{{ end }}
 
 serviceMonitor:
-  immich-server:
+  api:
     enabled: {{ .Values.immich.metrics.enabled }}
-    serviceName: immich-server
+    serviceName: immich-workers-api
     endpoints:
       - port: metrics-api
         scheme: http
+  microservices:
+    enabled: {{ .Values.immich.metrics.enabled }}
+    serviceName: immich-workers-microservices
+    endpoints:
       - port: metrics-ms
         scheme: http
 
@@ -101,11 +137,12 @@ persistence:
 # end of define
 {{- end }}
 
-{{- if .Values.server.enabled }}
+{{- if .Values.workers.enabled }}
 {{- $ctx := deepCopy (omit . "Values") }}
 {{- $_ := set $ctx "Values" dict }}
 {{- /* This part is needed so that bjw-s can reflectively resolve values like .Values.postgresql.global.postgresql.auth.username in the envVars */ -}}
 {{- $_ := set $ctx.Values "postgresql" (deepCopy .Values.postgresql) }}
-{{- $_ := merge $ctx.Values (deepCopy .Values.common) (include "immich.server.hardcodedValues" . | fromYaml) (deepCopy .Values.server) -}}
+{{- $_ := merge $ctx.Values (deepCopy .Values.common) (include "immich.workers.hardcodedValues" . | fromYaml) (deepCopy .Values.workers) -}}
+
 {{- include "bjw-s.common.loader.all" $ctx }}
 {{- end }}

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -4,19 +4,18 @@
 
 # These entries are shared between all the Immich components
 
-env:
-  REDIS_HOSTNAME: '{{ printf "%s-redis-master" .Release.Name }}'
-  DB_HOSTNAME: "{{ .Release.Name }}-postgresql"
-  DB_USERNAME: "{{ .Values.postgresql.global.postgresql.auth.username }}"
-  DB_DATABASE_NAME: "{{ .Values.postgresql.global.postgresql.auth.database }}"
-  # -- You should provide your own secret outside of this helm-chart and use `postgresql.global.postgresql.auth.existingSecret` to provide credentials to the postgresql instance
-  DB_PASSWORD: "{{ .Values.postgresql.global.postgresql.auth.password }}"
-  IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
-
-image:
-  tag: v1.118.0
-
 immich:
+  image:
+    tag: v1.118.0
+  env:
+    REDIS_HOSTNAME: '{{ printf "%s-redis-master" .Release.Name }}'
+    DB_HOSTNAME: '{{ .Release.Name }}-postgresql'
+    DB_USERNAME: '{{ .Values.postgresql.global.postgresql.auth.username }}'
+    DB_DATABASE_NAME: '{{ .Values.postgresql.global.postgresql.auth.database }}'
+    # -- You should provide your own secret outside of this helm-chart and use `postgresql.global.postgresql.auth.existingSecret` to provide credentials to the postgresql instance
+    DB_PASSWORD: '{{ .Values.postgresql.global.postgresql.auth.password }}'
+    IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
+
   metrics:
     # Enabling this will create the service monitors needed to monitor immich with the prometheus operator
     enabled: false
@@ -29,16 +28,16 @@ immich:
   # configuration is immich-config.json converted to yaml
   # ref: https://immich.app/docs/install/config-file/
   #
-  configuration: {}
+  configuration:
+    {}
     # trash:
     #   enabled: false
     #   days: 30
     # storageTemplate:
     #   enabled: true
-    #   template: "{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}"
+    #   template: '{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}'
 
 # Dependencies
-
 postgresql:
   enabled: false
   image:
@@ -67,36 +66,48 @@ redis:
     enabled: false
 
 # Immich components
-
 server:
   enabled: true
-  image:
-    repository: ghcr.io/immich-app/immich-server
-    pullPolicy: IfNotPresent
   ingress:
     main:
       enabled: false
       annotations:
         # proxy-body-size is set to 0 to remove the body limit on file uploads
-        nginx.ingress.kubernetes.io/proxy-body-size: "0"
+        nginx.ingress.kubernetes.io/proxy-body-size: '0'
       hosts:
         - host: immich.local
           paths:
-            - path: "/"
+            - path: '/'
       tls: []
 
 machine-learning:
   enabled: true
-  image:
-    repository: ghcr.io/immich-app/immich-machine-learning
-    pullPolicy: IfNotPresent
   env:
     TRANSFORMERS_CACHE: /cache
   persistence:
     cache:
       enabled: true
       size: 10Gi
-      # Optional: Set this to pvc to avoid downloading the ML models every start.
+      # Optional: Set this to a persistentVolumeClaim to avoid downloading the ML models every start.
       type: emptyDir
       accessMode: ReadWriteMany
       # storageClass: your-class
+
+workers:
+  enabled: false
+  controllers:
+    api:
+      replicas: 1
+    microservices:
+      replicas: 1
+  ingress:
+    api:
+      enabled: false
+      annotations:
+        # proxy-body-size is set to 0 to remove the body limit on file uploads
+        nginx.ingress.kubernetes.io/proxy-body-size: '0'
+      hosts:
+        - host: immich.local
+          paths:
+            - path: '/'
+      tls: []


### PR DESCRIPTION
- Upgrade to latest charts library. 
- Allow new top level config for 'worker' which allows separating api/web from microservices, and these can be independently scaled
- Add check to only configure server or worker, not both
- Move `env` and `image.tag `to `immich` section
- Add debug template to dump objs (useful for dev improvements to the chart)

Note - this is a breaking change, and chart's major version has been revved. 