### PR TITLE
feat: add startup probe for machine learning

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.8.4
+version: 0.8.5
 appVersion: v1.119.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg
@@ -28,9 +28,5 @@ dependencies:
     version: 19.5.3
 annotations:
   artifacthub.io/category: storage
-  artifacthub.io/changes: |-
-    - kind: changed
-      description: Bumped pgvecto-rs to pg14-v0.2.0
-      links:
-        - name: Release Notes Breaking Changes
-          url: https://github.com/immich-app/immich/releases/tag/v1.95.1
+  artifacthub.io/changes: |
+    - Added default startupProbe for machine-learning to allow for preloading models

--- a/charts/immich/templates/machine-learning.yaml
+++ b/charts/immich/templates/machine-learning.yaml
@@ -28,7 +28,16 @@ probes:
       failureThreshold: 3
   readiness: *probes
   startup:
-    enabled: false
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        path: /ping
+        port: http
+      initialDelaySeconds: 0
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 60
 {{- end }}
 
 {{- /* Have to reference with index here because the dash breaks a normal dereference */}}


### PR DESCRIPTION
I ran into issues with `machine-learning` pod not having enough time to download and startup after adding `MACHINE_LEARNING_PRELOAD__CLIP`.