### PR TITLE
Add resource memory request and limit

### DIFF
--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -59,6 +59,12 @@ postgresql:
           CREATE EXTENSION cube;
           CREATE EXTENSION earthdistance;
           CREATE EXTENSION vectors;
+    resources:
+      # recommended to set the memory limit to at least 2Gi
+      requests:
+        memory: 1Gi
+      limits:
+        memory: 2Gi
 
 redis:
   enabled: false


### PR DESCRIPTION
Without this setting it is set to a very low value, I think 192 Mi which breaks immich update to 1.122.2

See: https://github.com/immich-app/immich/discussions/14499