### PR TITLE
feat: support different volume kinds for library

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.9.0
+version: 0.9.1
 appVersion: v1.119.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg
@@ -29,8 +29,4 @@ dependencies:
 annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
-    - kind: deprecated
-      description: Deprecated postgres chart dependency
-      links:
-        - name: Details
-          url: https://github.com/immich-app/immich-charts/issues/149
+    - Added support for different volume kinds for library

--- a/charts/immich/templates/checks.yaml
+++ b/charts/immich/templates/checks.yaml
@@ -1,5 +1,3 @@
-{{- $name := .Values.immich.persistence.library.existingClaim | required ".Values.immich.persistence.library.existingClaim is required." -}}
-
 {{ if .Values.postgresql.enabled }}
   {{ if not .Values.useDeprecatedPostgresChart}}
     {{ fail "The postgres subchart is deprecated. Please see https://github.com/immich-app/immich-charts/issues/149 for more detail." }}

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -77,10 +77,7 @@ persistence:
     type: configMap
     name: {{ .Release.Name }}-immich-config
 {{- end }}
-  library:
-    enabled: true
-    mountPath: /usr/src/app/upload
-    existingClaim: {{ .Values.immich.persistence.library.existingClaim }}
+  library: {{ .Values.immich.persistence.library |  toYaml | nindent 4 }}
 {{- end }}
 
 {{ if .Values.server.enabled }}

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -23,6 +23,8 @@ immich:
   persistence:
     # Main data store for all photos shared between different components.
     library:
+      enabled: true
+      mountPath: /usr/src/app/upload
       # Automatically creating the library volume is not supported by this chart
       # You have to specify an existing PVC to use
       existingClaim:


### PR DESCRIPTION
At the moment it is not possible to use a NFS volume for the library - this change allows to define different kinds of volumes