### PR TITLE
feat: configure custom ports for machine learning and server services

### DIFF
--- a/charts/immich/templates/machine-learning.yaml
+++ b/charts/immich/templates/machine-learning.yaml
@@ -2,6 +2,9 @@
 global:
   nameOverride: machine-learning
 
+env:
+  IMMICH_PORT: 3003
+
 controller:
   strategy: RollingUpdate
 

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -9,6 +9,7 @@ env:
   {{- if .Values.immich.configuration }}
       IMMICH_CONFIG_FILE: /config/immich-config.yaml
   {{- end }}
+  IMMICH_PORT: 2283
 
 {{- if .Values.immich.configuration }}
 podAnnotations:


### PR DESCRIPTION
In recent immich versions, you have to configure the `IMMICH_PORT` env variable, otherwise you get the following errors:

In the machine learning component the error log is:

```bash
Error: 'tcp://10.43.34.135:80' is not a valid port number.

stream closed EOF for immich/immich-machine-learning-55557bd9c-x4x6h (immich-machine-learning)
```
In the server component the error is the following:

```bash
Initializing Immich v1.119.0
Detected CPU Cores: 4
/usr/src/app/node_modules/@nestjs/config/dist/config.module.js:86
                throw new Error(`Config validation error: ${error.message}`);
                ^

Error: Config validation error: "IMMICH_PORT" must be a number
    at ConfigModule.forRoot (/usr/src/app/node_modules/@nestjs/config/dist/config.module.js:86:23)
    at Object.<anonymous> (/usr/src/app/dist/app.module.js:57:27)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at Module.require (node:internal/modules/cjs/loader:1311:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/usr/src/app/dist/main.js:6:22)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)

Node.js v20.18.0
stream closed EOF for immich/immich-server-745dd9757f-jlpxc (immich-server)

```

By adding the env variables, the problems are solved