### PR TITLE
Add separate microservices pod

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.9.6
+version: 0.9.2
 appVersion: v1.120.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.9.5
+version: 0.9.6
 appVersion: v1.120.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.9.1
+version: 0.9.2
 appVersion: v1.120.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.9.4
+version: 0.9.5
 appVersion: v1.120.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.9.2
+version: 0.9.3
 appVersion: v1.120.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.9.3
+version: 0.9.4
 appVersion: v1.120.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
 version: 0.9.1
-appVersion: v1.119.0
+appVersion: v1.120.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg
 sources:

--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -1,6 +1,6 @@
-{{- define "immich.server.hardcodedValues" -}}
+{{- define "immich.microservices.hardcodedValues" -}}
 global:
-  nameOverride: server
+  nameOverride: microservices
 
 env:
   {{ if .Values.immich.metrics.enabled }}
@@ -9,7 +9,7 @@ env:
   {{- if .Values.immich.configuration }}
       IMMICH_CONFIG_FILE: /config/immich-config.yaml
   {{- end }}
-      IMMICH_WORKERS_INCLUDE: api
+      IMMICH_WORKERS_INCLUDE: microservices
 
 {{- if .Values.immich.configuration }}
 podAnnotations:
@@ -18,27 +18,6 @@ podAnnotations:
 
 controller:
   strategy: RollingUpdate
-
-service:
-  main:
-    enabled: true
-    primary: true
-    type: ClusterIP
-    ports:
-      http:
-        enabled: true
-        primary: true
-        port: 2283
-        protocol: HTTP
-      metrics-api:
-        enabled: {{ .Values.immich.metrics.enabled }}
-        port: 8081
-        protocol: HTTP
-      metrics-ms:
-        enabled: {{ .Values.immich.metrics.enabled }}
-        port: 8082
-        protocol: HTTP
-
 
 serviceMonitor:
   main:
@@ -54,9 +33,10 @@ probes:
     enabled: true
     custom: true
     spec:
-      httpGet:
-        path: /api/server/ping
-        port: http
+      exec:
+        command:
+          - pgrep
+          - immich
       initialDelaySeconds: 0
       periodSeconds: 10
       timeoutSeconds: 1
@@ -66,9 +46,10 @@ probes:
     enabled: true
     custom: true
     spec:
-      httpGet:
-        path: /api/server/ping
-        port: http
+      exec:
+        command:
+          - pgrep
+          - immich
       initialDelaySeconds: 0
       periodSeconds: 10
       timeoutSeconds: 1
@@ -87,9 +68,9 @@ persistence:
     existingClaim: {{ .Values.immich.persistence.library.existingClaim }}
 {{- end }}
 
-{{ if .Values.server.enabled }}
+{{ if .Values.microservices.enabled }}
 {{- $ctx := deepCopy . -}}
-{{- $_ := get .Values "server" | mergeOverwrite $ctx.Values -}}
-{{- $_ = include "immich.server.hardcodedValues" . | fromYaml | merge $ctx.Values -}}
+{{- $_ := get .Values "microservices" | mergeOverwrite $ctx.Values -}}
+{{- $_ = include "immich.microservices.hardcodedValues" . | fromYaml | merge $ctx.Values -}}
 {{- include "bjw-s.common.loader.all" $ctx }}
 {{ end }}

--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -20,7 +20,7 @@ controller:
 
 service:
   main:
-    enabled: true
+    enabled: false
     primary: true
     type: ClusterIP
     ports:
@@ -52,9 +52,9 @@ probes:
     enabled: true
     custom: true
     spec:
-      httpGet:
-        path: /api/server/ping
-        port: http
+      exec:
+        command:
+        - immich-healthcheck
       initialDelaySeconds: 0
       periodSeconds: 10
       timeoutSeconds: 1
@@ -64,9 +64,9 @@ probes:
     enabled: true
     custom: true
     spec:
-      httpGet:
-        path: /api/server/ping
-        port: http
+      exec:
+        command:
+        - immich-healthcheck
       initialDelaySeconds: 0
       periodSeconds: 10
       timeoutSeconds: 1

--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -19,6 +19,26 @@ podAnnotations:
 controller:
   strategy: RollingUpdate
 
+service:
+  main:
+    enabled: false
+    primary: true
+    type: ClusterIP
+    ports:
+      http:
+        enabled: true
+        primary: true
+        port: 2283
+        protocol: HTTP
+      metrics-api:
+        enabled: {{ .Values.immich.metrics.enabled }}
+        port: 8081
+        protocol: HTTP
+      metrics-ms:
+        enabled: {{ .Values.immich.metrics.enabled }}
+        port: 8082
+        protocol: HTTP
+
 serviceMonitor:
   main:
     enabled: {{ .Values.immich.metrics.enabled }}

--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -55,7 +55,7 @@ probes:
     spec:
       exec:
         command:
-          - pgrep
+          - /usr/bin/pgrep
           - immich
       initialDelaySeconds: 0
       periodSeconds: 10
@@ -68,7 +68,7 @@ probes:
     spec:
       exec:
         command:
-          - pgrep
+          - /usr/bin/pgrep
           - immich
       initialDelaySeconds: 0
       periodSeconds: 10

--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -20,7 +20,7 @@ controller:
 
 service:
   main:
-    enabled: false
+    enabled: true
     primary: true
     type: ClusterIP
     ports:

--- a/charts/immich/templates/microservices.yaml
+++ b/charts/immich/templates/microservices.yaml
@@ -9,7 +9,6 @@ env:
   {{- if .Values.immich.configuration }}
       IMMICH_CONFIG_FILE: /config/immich-config.yaml
   {{- end }}
-      IMMICH_WORKERS_INCLUDE: microservices
 
 {{- if .Values.immich.configuration }}
 podAnnotations:
@@ -53,10 +52,9 @@ probes:
     enabled: true
     custom: true
     spec:
-      exec:
-        command:
-          - /usr/bin/pgrep
-          - immich
+      httpGet:
+        path: /api/server/ping
+        port: http
       initialDelaySeconds: 0
       periodSeconds: 10
       timeoutSeconds: 1
@@ -66,10 +64,9 @@ probes:
     enabled: true
     custom: true
     spec:
-      exec:
-        command:
-          - /usr/bin/pgrep
-          - immich
+      httpGet:
+        path: /api/server/ping
+        port: http
       initialDelaySeconds: 0
       periodSeconds: 10
       timeoutSeconds: 1

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -88,6 +88,23 @@ server:
             - path: "/"
       tls: []
 
+microservices:
+  enabled: true
+  image:
+    repository: ghcr.io/immich-app/immich-server
+    pullPolicy: IfNotPresent
+  ingress:
+    main:
+      enabled: false
+      annotations:
+        # proxy-body-size is set to 0 to remove the body limit on file uploads
+        nginx.ingress.kubernetes.io/proxy-body-size: "0"
+      hosts:
+        - host: immich.local
+          paths:
+            - path: "/"
+      tls: []
+
 machine-learning:
   enabled: true
   image:


### PR DESCRIPTION
Separate microservice pod without API.
Disable microservices on server pod.

It guarentees better separation of resources and help avoid interference when doing huge transcoding tasks which previously caused API to be sometimes irresponsive.