### PR TITLE
Change Server rollout strategy to Recreate

### DIFF
--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -16,7 +16,7 @@ podAnnotations:
 {{- end }}
 
 controller:
-  strategy: RollingUpdate
+  strategy: Recreate
 
 service:
   main:


### PR DESCRIPTION
since Server is a StatefulSet with an attached persistent volume, we must change rollout strategy to recreate to be able to detach the volume and attach it to the new versioned pod.