### PR TITLE
fix: allow setting server deployment strategy in values

### DIFF
--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -16,7 +16,7 @@ podAnnotations:
 {{- end }}
 
 controller:
-  strategy: RollingUpdate
+  strategy: {{ .Values.server.strategy }}
 
 service:
   main:

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -73,6 +73,7 @@ redis:
 
 server:
   enabled: true
+  strategy: RollingUpdate
   image:
     repository: ghcr.io/immich-app/immich-server
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Adds configurable value for the deployment's strategy (keeps default of `RollingUpdate`, but allows overriding e.g. when the PVC is `ReadWriteOnce` and it needs to be `Recreate`)