### PR TITLE
fix: immich-configmap breaks when using oci version of chart

### DIFF
--- a/charts/immich/templates/immich-config.yml
+++ b/charts/immich/templates/immich-config.yml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    helm.sh/chart: {{ printf "%s-%s\n" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 data:
   immich-config.yaml: |
 {{- .Values.immich.configuration | toYaml | nindent 4 }}


### PR DESCRIPTION
I get the following error with the oci version of the chart when using `immich.configuration` options.

```
Helm install failed for release self-hosted/immich with chart immich@0.9.2+17ae5ad735c4:
1 error occurred: * ConfigMap "immich-immich-config" is invalid: metadata.labels: Invalid value: "immich-0.9.2+17ae5ad735c4": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

I copied the way the app-template is creating it's labels, from here: https://github.com/bjw-s/helm-charts/blob/main/charts/library/common/templates/lib/chart/_names.tpl#L34

Tested with flux on my home-ops cluster, and this version works