### PR TITLE
feat!: remove deprecated postgres subchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ There are a few things that you are required to configure in your values.yaml be
 * You need to separately create a PVC for your library volume and configure `immich.persistence.library.existingClaim` to reference that PVC
 * You need to make sure that Immich has access to a redis and postgresql instance. 
   * Redis can be enabled directly in the values.yaml, or by manually setting the `env` to point to an existing instance.
-  * You need to deploy a suitable postgres instance with the pgvecto.rs extension yourself.
+  * You need to deploy a suitable postgres instance with the pgvecto.rs extension yourself. It is recommended to use [cloudnative-pg](https://cloudnative-pg.io/) with the [tensorcord/cloudnative-pgvecto.rs](https://github.com/tensorchord/cloudnative-pgvecto.rs/pkgs/container/cloudnative-pgvecto.rs) container image. An example cluster manifest can be found [here](./cloudnative-pg.yaml).
 * You need to set `image.tag` to the version you want to use, as this chart does not update with every Immich release.
 
 # Configuration

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.10.0
+version: 0.9.3
 appVersion: v1.119.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.9.2
+version: 0.10.0
 appVersion: v1.119.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg
@@ -18,10 +18,6 @@ dependencies:
   - name: common
     repository: https://bjw-s.github.io/helm-charts
     version: 1.4.0
-  - name: postgresql
-    condition: postgresql.enabled
-    repository: https://charts.bitnami.com/bitnami
-    version: 16.0.0
   - name: redis
     condition: redis.enabled
     repository: https://charts.bitnami.com/bitnami

--- a/charts/immich/templates/checks.yaml
+++ b/charts/immich/templates/checks.yaml
@@ -1,7 +1,1 @@
 {{- $name := .Values.immich.persistence.library.existingClaim | required ".Values.immich.persistence.library.existingClaim is required." -}}
-
-{{ if .Values.postgresql.enabled }}
-  {{ if not .Values.useDeprecatedPostgresChart}}
-    {{ fail "The postgres subchart is deprecated. Please see https://github.com/immich-app/immich-charts/issues/149 for more detail." }}
-  {{ end }}
-{{ end }}

--- a/charts/immich/templates/checks.yaml
+++ b/charts/immich/templates/checks.yaml
@@ -1,1 +1,5 @@
 {{- $name := .Values.immich.persistence.library.existingClaim | required ".Values.immich.persistence.library.existingClaim is required." -}}
+
+{{ if .Values.postgresql }}
+    {{ fail "The postgres subchart has been removed. Please see https://github.com/immich-app/immich-charts/issues/149 for more detail." }}
+{{ end }}

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -6,11 +6,6 @@
 
 env:
   REDIS_HOSTNAME: '{{ printf "%s-redis-master" .Release.Name }}'
-  DB_HOSTNAME: "{{ .Release.Name }}-postgresql"
-  DB_USERNAME: "{{ .Values.postgresql.global.postgresql.auth.username }}"
-  DB_DATABASE_NAME: "{{ .Values.postgresql.global.postgresql.auth.database }}"
-  # -- You should provide your own secret outside of this helm-chart and use `postgresql.global.postgresql.auth.existingSecret` to provide credentials to the postgresql instance
-  DB_PASSWORD: "{{ .Values.postgresql.global.postgresql.auth.password }}"
   IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
 
 image:
@@ -38,31 +33,6 @@ immich:
     #   template: "{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}"
 
 # Dependencies
-
-# DEPRECATED
-# The postgres subchart is deprecated and will be removed in chart version 0.10.0
-# See https://github.com/immich-app/immich-charts/issues/149 for more detail.
-postgresql:
-  enabled: false
-  image:
-    repository: tensorchord/pgvecto-rs
-    tag: pg14-v0.2.0@sha256:739cdd626151ff1f796dc95a6591b55a714f341c737e27f045019ceabf8e8c52
-  global:
-    postgresql:
-      auth:
-        username: immich
-        database: immich
-        password: immich
-  primary:
-    containerSecurityContext:
-      readOnlyRootFilesystem: false
-    initdb:
-      scripts:
-        create-extensions.sql: |
-          CREATE EXTENSION cube;
-          CREATE EXTENSION earthdistance;
-          CREATE EXTENSION vectors;
-
 redis:
   enabled: false
   architecture: standalone

--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: immich-database-secret
+type: kubernetes.io/basic-auth
+stringData:
+  username: immich
+  password: <set-a-password>
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: immich-database
+spec:
+  instances: 1
+
+  storage:
+    size: 1Gi
+
+  imageName: ghcr.io/tensorchord/cloudnative-pgvecto.rs:16
+
+  postgresql:
+    shared_preload_libraries:
+      - "vectors.so"
+
+  bootstrap:
+    initdb:
+      database: immich
+      owner: immich
+      secret:
+        name: immich-database-secret
+      postInitApplicationSQL:
+        # Commands based on: https://immich.app/docs/administration/postgres-standalone/#without-superuser-permission
+        - CREATE EXTENSION vectors;
+        - CREATE EXTENSION earthdistance CASCADE;
+        - ALTER DATABASE immich SET search_path TO "$user", public, vectors;
+        - ALTER SCHEMA vectors OWNER TO immich;

--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -18,7 +18,7 @@ spec:
   storage:
     size: 1Gi
 
-  imageName: ghcr.io/tensorchord/cloudnative-pgvecto.rs:16
+  imageName: ghcr.io/tensorchord/cloudnative-pgvecto.rs:16-v0.3.0
 
   postgresql:
     shared_preload_libraries:


### PR DESCRIPTION
If the update to the common lib is merged and we need to bump to 0.10.0 we might as well get rid of the deprecated subchart at the same time.