### PR TITLE
feat: Optionally, provision PVC automatically using a storageClass, if no existingClaim provided

### DIFF
--- a/charts/immich/templates/checks.yaml
+++ b/charts/immich/templates/checks.yaml
@@ -1,5 +1,3 @@
-{{- $name := .Values.immich.persistence.library.existingClaim | required ".Values.immich.persistence.library.existingClaim is required." -}}
-
 {{ if .Values.postgresql.enabled }}
   {{ if not .Values.useDeprecatedPostgresChart}}
     {{ fail "The postgres subchart is deprecated. Please see https://github.com/immich-app/immich-charts/issues/149 for more detail." }}

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -83,7 +83,11 @@ persistence:
   library:
     enabled: true
     mountPath: /usr/src/app/upload
+    {{- if .Values.immich.persistence.library.existingClaim }}
     existingClaim: {{ .Values.immich.persistence.library.existingClaim }}
+    {{- else }}
+    existingClaim: {{ .Release.Name }}-library
+    {{- end }}
 {{- end }}
 
 {{ if .Values.server.enabled }}

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -85,6 +85,8 @@ persistence:
     mountPath: /usr/src/app/upload
     {{- if .Values.immich.persistence.library.existingClaim }}
     existingClaim: {{ .Values.immich.persistence.library.existingClaim }}
+    {{- else if .Values.immich.persistence.library.claimName }}
+    existingClaim: {{ .Values.immich.persistence.library.claimName }}
     {{- else }}
     existingClaim: {{ .Release.Name }}-library
     {{- end }}

--- a/charts/immich/templates/storage.yaml
+++ b/charts/immich/templates/storage.yaml
@@ -1,0 +1,47 @@
+{{- define "immich.createPVC" -}}
+{{- $releaseName := .Release.Name -}}
+{{- $chartName := .Chart.Name -}}
+{{- $name := .name | default "library" -}}
+{{- $existingClaim := .existingClaim -}}
+{{- $storageClass := .storageClass -}}
+{{- $size := .size | default "10Gi" -}}
+{{- $accessModes := .accessModes | default (list "ReadWriteOnce") -}}
+{{- $volumeName := .volumeName -}}
+
+{{- if not $existingClaim -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ printf "%s-%s" $releaseName $name }}
+  labels:
+    app.kubernetes.io/name: {{ $chartName }}
+    app.kubernetes.io/instance: {{ $releaseName }}
+    app.kubernetes.io/component: {{ $name }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml $accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ $size }}
+  {{- if $storageClass }}
+  storageClassName: {{ $storageClass }}
+  {{- end }}
+  {{- if $volumeName }}
+  volumeName: {{ $volumeName }}
+  {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{- if .Values.server.enabled }}
+{{- if not .Values.immich.persistence.library.existingClaim }}
+{{- $ctx := dict "name" "library" "existingClaim" .Values.immich.persistence.library.existingClaim "storageClass" .Values.immich.persistence.library.storageClass "size" .Values.immich.persistence.library.size "accessModes" .Values.immich.persistence.library.accessModes "volumeName" .Values.immich.persistence.library.volumeName }}
+{{- $_ := merge $ctx (dict "Values" .Values) }}
+{{- $_ := set $ctx "Release" .Release }}
+{{- $_ := set $ctx "Chart" .Chart }}
+{{- include "immich.createPVC" $ctx }}
+{{- end }}
+{{- end }}

--- a/charts/immich/templates/storage.yaml
+++ b/charts/immich/templates/storage.yaml
@@ -8,6 +8,8 @@
 {{- $size := .size | default "10Gi" -}}
 {{- $accessModes := .accessModes | default (list "ReadWriteOnce") -}}
 {{- $volumeName := .volumeName -}}
+{{- $retain := .retain | default true -}}
+{{- $annotations := .annotations | default dict -}}
 
 {{- if not $existingClaim -}}
 apiVersion: v1
@@ -18,9 +20,12 @@ metadata:
     app.kubernetes.io/name: {{ $chartName }}
     app.kubernetes.io/instance: {{ $releaseName }}
     app.kubernetes.io/component: {{ $name }}
-  {{- with .annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+  {{- if $retain }}
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  {{- if $annotations }}
+    {{- toYaml $annotations | nindent 4 }}
   {{- end }}
 spec:
   accessModes:
@@ -39,7 +44,7 @@ spec:
 
 {{- if .Values.server.enabled }}
 {{- if not .Values.immich.persistence.library.existingClaim }}
-{{- $ctx := dict "name" "library" "existingClaim" .Values.immich.persistence.library.existingClaim "claimName" .Values.immich.persistence.library.claimName "storageClass" .Values.immich.persistence.library.storageClass "size" .Values.immich.persistence.library.size "accessModes" .Values.immich.persistence.library.accessModes "volumeName" .Values.immich.persistence.library.volumeName }}
+{{- $ctx := dict "name" "library" "existingClaim" .Values.immich.persistence.library.existingClaim "claimName" .Values.immich.persistence.library.claimName "storageClass" .Values.immich.persistence.library.storageClass "size" .Values.immich.persistence.library.size "accessModes" .Values.immich.persistence.library.accessModes "volumeName" .Values.immich.persistence.library.volumeName "retain" .Values.immich.persistence.library.retain "annotations" .Values.immich.persistence.library.annotations }}
 {{- $_ := merge $ctx (dict "Values" .Values) }}
 {{- $_ := set $ctx "Release" .Release }}
 {{- $_ := set $ctx "Chart" .Chart }}

--- a/charts/immich/templates/storage.yaml
+++ b/charts/immich/templates/storage.yaml
@@ -3,6 +3,7 @@
 {{- $chartName := .Chart.Name -}}
 {{- $name := .name | default "library" -}}
 {{- $existingClaim := .existingClaim -}}
+{{- $claimName := .claimName -}}
 {{- $storageClass := .storageClass -}}
 {{- $size := .size | default "10Gi" -}}
 {{- $accessModes := .accessModes | default (list "ReadWriteOnce") -}}
@@ -12,7 +13,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ printf "%s-%s" $releaseName $name }}
+  name: {{ if $claimName }}{{ $claimName }}{{ else }}{{ $releaseName }}-{{ $name }}{{ end }}
   labels:
     app.kubernetes.io/name: {{ $chartName }}
     app.kubernetes.io/instance: {{ $releaseName }}
@@ -38,7 +39,7 @@ spec:
 
 {{- if .Values.server.enabled }}
 {{- if not .Values.immich.persistence.library.existingClaim }}
-{{- $ctx := dict "name" "library" "existingClaim" .Values.immich.persistence.library.existingClaim "storageClass" .Values.immich.persistence.library.storageClass "size" .Values.immich.persistence.library.size "accessModes" .Values.immich.persistence.library.accessModes "volumeName" .Values.immich.persistence.library.volumeName }}
+{{- $ctx := dict "name" "library" "existingClaim" .Values.immich.persistence.library.existingClaim "claimName" .Values.immich.persistence.library.claimName "storageClass" .Values.immich.persistence.library.storageClass "size" .Values.immich.persistence.library.size "accessModes" .Values.immich.persistence.library.accessModes "volumeName" .Values.immich.persistence.library.volumeName }}
 {{- $_ := merge $ctx (dict "Values" .Values) }}
 {{- $_ := set $ctx "Release" .Release }}
 {{- $_ := set $ctx "Chart" .Chart }}

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -38,6 +38,9 @@ immich:
       volumeName:
       # Optional annotations for PersistentVolumeClaim
       annotations: {}
+      # Set helm resource retention policy for generated PersistentVolumeClaim.
+      # Warning: Disabling this will delete the PersistentVolumeClaim when the chart is uninstalled, thus leading to data loss!
+      retain: true
   # configuration is immich-config.json converted to yaml
   # ref: https://immich.app/docs/install/config-file/
   #

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -28,12 +28,14 @@ immich:
       existingClaim:
       # Alternatively, the chart can create a new PersistentVolumeClaim using the specified StorageClass
       # and additional parameters below.
-      storageClass: ""
+      storageClass:
       size: "10Gi"
       accessModes:
         - ReadWriteOnce
-      # Optionallyvolume name to bind to.
-      volumeName: ""
+      # Optionally specify the name of the PersistentVolumeClaim to create.
+      claimName:
+      # Optionally volume name to bind to.
+      volumeName:
       # Optional annotations for PersistentVolumeClaim
       annotations: {}
   # configuration is immich-config.json converted to yaml

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -23,9 +23,19 @@ immich:
   persistence:
     # Main data store for all photos shared between different components.
     library:
-      # Automatically creating the library volume is not supported by this chart
-      # You have to specify an existing PVC to use
+      # You can choose to privide an existing PersistentVolumeClaim here.
+      # In this case, the other storage parameters below will be ignored.
       existingClaim:
+      # Alternatively, the chart can create a new PersistentVolumeClaim using the specified StorageClass
+      # and additional parameters below.
+      storageClass: ""
+      size: "10Gi"
+      accessModes:
+        - ReadWriteOnce
+      # Optionallyvolume name to bind to.
+      volumeName: ""
+      # Optional annotations for PersistentVolumeClaim
+      annotations: {}
   # configuration is immich-config.json converted to yaml
   # ref: https://immich.app/docs/install/config-file/
   #


### PR DESCRIPTION
This change implements a feature outlined in #193.

The proposed change allows users to omit the `immich.persistence.library.existingClaim` and instead specify a `.storageClass` (and other optional parameters) to automatically provision a PVC as required.
This feature is targeted particularly at more advanced users, aware of dynamic provisioning mechanisms and familiar with potential risks and configuration pitfalls (like not configuring proper retention policies).

To avoid accidental data loss, the chart will set the helm resource retention policy of the provisioned PVC to `keep` by default. This will not allow users to accidentally delete the provisioned PVC when they uninstall the helm chart.