### PR TITLE
Adding NFS support for library persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ $ helm install --create-namespace --namespace immich immich oci://ghcr.io/immich
 You should not copy the full values.yaml from this repository. Only set the values that you want to override.
 
 There are a few things that you are required to configure in your values.yaml before installing the chart:
-* You need to separately create a PVC for your library volume and configure `immich.persistence.library.existingClaim` to reference that PVC
+* You need to configure storage for your library volume using **one** of these options:
+  * **Option 1**: Create a PVC for your library volume and configure `immich.persistence.library.existingClaim` to reference that PVC
+  * **Option 2**: Use an NFS mount by setting `immich.persistence.library.nfs.enabled: true` and configuring the `server` and `path` values
 * You need to make sure that Immich has access to a redis and postgresql instance. 
   * Redis can be enabled directly in the values.yaml, or by manually setting the `env` to point to an existing instance.
   * You need to deploy a suitable postgres instance with the vectorchord extension yourself. It is recommended to use [cloudnative-pg](https://cloudnative-pg.io/) with the [tensorchord/cloudnative-vectorchord](https://github.com/tensorchord/cloudnative-vectorchord/pkgs/container/cloudnative-vectorchord) container image. An example cluster manifest can be found [here](./local/cloudnative-pg.yaml).

--- a/charts/immich/templates/checks.yaml
+++ b/charts/immich/templates/checks.yaml
@@ -1,5 +1,20 @@
-{{- $name := .Values.immich.persistence.library.existingClaim | required ".Values.immich.persistence.library.existingClaim is required." -}}
-{{- if not (kindIs "string" $name) -}}{{- fail ".Values.immich.persistence.library.existingClaim must be a string" -}}{{- end -}}
+{{- $hasExistingClaim := .Values.immich.persistence.library.existingClaim -}}
+{{- $hasNfs := .Values.immich.persistence.library.nfs.enabled -}}
+{{- if and (not $hasExistingClaim) (not $hasNfs) -}}
+  {{- fail "Either .Values.immich.persistence.library.existingClaim or .Values.immich.persistence.library.nfs.enabled must be set." -}}
+{{- end -}}
+{{- if and $hasExistingClaim $hasNfs -}}
+  {{- fail "Cannot set both .Values.immich.persistence.library.existingClaim and .Values.immich.persistence.library.nfs.enabled. Choose one." -}}
+{{- end -}}
+{{- if $hasExistingClaim -}}
+  {{- if not (kindIs "string" $hasExistingClaim) -}}{{- fail ".Values.immich.persistence.library.existingClaim must be a string" -}}{{- end -}}
+{{- end -}}
+{{- if $hasNfs -}}
+  {{- $nfsServer := .Values.immich.persistence.library.nfs.server | required ".Values.immich.persistence.library.nfs.server is required when nfs.enabled is true." -}}
+  {{- $nfsPath := .Values.immich.persistence.library.nfs.path | required ".Values.immich.persistence.library.nfs.path is required when nfs.enabled is true." -}}
+  {{- if not (kindIs "string" $nfsServer) -}}{{- fail ".Values.immich.persistence.library.nfs.server must be a string" -}}{{- end -}}
+  {{- if not (kindIs "string" $nfsPath) -}}{{- fail ".Values.immich.persistence.library.nfs.path must be a string" -}}{{- end -}}
+{{- end -}}
 
 {{ if .Values.postgresql }}
     {{ fail "The postgres subchart has been removed. Please see https://github.com/immich-app/immich-charts/issues/149 for more detail." }}

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -83,7 +83,13 @@ persistence:
   library:
     enabled: true
     mountPath: /usr/src/app/upload
+{{- if .Values.immich.persistence.library.existingClaim }}
     existingClaim: {{ .Values.immich.persistence.library.existingClaim }}
+{{- else if .Values.immich.persistence.library.nfs.enabled }}
+    type: nfs
+    server: {{ .Values.immich.persistence.library.nfs.server }}
+    path: {{ .Values.immich.persistence.library.nfs.path }}
+{{- end }}
 {{- end }}
 
 {{ if .Values.server.enabled }}

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -4,6 +4,13 @@
 
 # These entries are shared between all the Immich components
 
+# securityContext:
+#   runAsNonRoot: true
+#   runAsUser: 1027
+#   runAsGroup: 100
+#   fsGroup: 100
+#   fsGroupChangePolicy: "OnRootMismatch"
+
 env:
   REDIS_HOSTNAME: '{{ printf "%s-valkey" .Release.Name }}'
   IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
@@ -19,8 +26,19 @@ immich:
     # Main data store for all photos shared between different components.
     library:
       # Automatically creating the library volume is not supported by this chart
-      # You have to specify an existing PVC to use
+      # You must specify either an existing PVC or an NFS mount (but not both)
+
+      # Option 1: Use an existing PVC
+      # existingClaim: my-immich-library-pvc
       existingClaim:
+
+      # Option 2: Use an NFS mount
+      nfs:
+        enabled: false
+        # NFS server hostname or IP address
+        server: nas1-10g.l0l0.lol
+        # Path to the NFS export
+        path: "/volume1/media"
   # configuration is immich-config.json converted to yaml
   # ref: https://immich.app/docs/install/config-file/
   #

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -4,13 +4,6 @@
 
 # These entries are shared between all the Immich components
 
-# securityContext:
-#   runAsNonRoot: true
-#   runAsUser: 1027
-#   runAsGroup: 100
-#   fsGroup: 100
-#   fsGroupChangePolicy: "OnRootMismatch"
-
 env:
   REDIS_HOSTNAME: '{{ printf "%s-valkey" .Release.Name }}'
   IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
@@ -36,9 +29,9 @@ immich:
       nfs:
         enabled: false
         # NFS server hostname or IP address
-        server: nas1-10g.l0l0.lol
+        # server: <nfs-server>
         # Path to the NFS export
-        path: "/volume1/media"
+        # path: "/volume1/media"
   # configuration is immich-config.json converted to yaml
   # ref: https://immich.app/docs/install/config-file/
   #


### PR DESCRIPTION
Like others, I use my NAS to store my Immich library. Rather than move the library to a pvc and have to worry about replicas/expansion, I modified the helm chart to support mounting the library directly from an NFS server. 