### PR TITLE
fix: pvc is not a valid type, should be persistentVolumeClaim

### DIFF
--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -51,7 +51,7 @@ valkey:
     data:
       enabled: true
       size: 1Gi
-      # Optional: Set this to pvc to keep job queues persistent
+      # Optional: Set this to persistentVolumeClaim to keep job queues persistent
       type: emptyDir
       accessMode: ReadWriteOnce
       # storageClass: your-class
@@ -96,7 +96,7 @@ machine-learning:
     cache:
       enabled: true
       size: 10Gi
-      # Optional: Set this to pvc to avoid downloading the ML models every start.
+      # Optional: Set this to persistentVolumeClaim to avoid downloading the ML models every start.
       type: emptyDir
       accessMode: ReadWriteMany
       # storageClass: your-class


### PR DESCRIPTION
I was getting some strange errors:

Not a valid persistence.type (pvc)

When updating from pre 0.10. I looked around and I think that the common-library may be now stricter with the type, maybe?

https://bjw-s-labs.github.io/helm-charts/docs/common-library/storage/globalOptions/#type

Updating the comments to reflect that.