### PR TITLE
chore: add example database connection env vars

### DIFF
--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -14,6 +14,15 @@ controllers:
           REDIS_HOSTNAME: '{{ printf "%s-valkey" .Release.Name }}'
           IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
           # Add the env vars to connect to your database here.
+          # For more information, see https://docs.immich.app/install/environment-variables
+          # DB_HOSTNAME: example.cluster.local
+          # DB_USERNAME: immich
+          # DB_DATABASE_NAME: immich
+          # DB_PASSWORD:
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: immich-database-app
+          #       key: password
 
 immich:
   metrics:


### PR DESCRIPTION
In this PR, I add commented-out examples of the database-related configuration values that are **required** for using Immich, along with links to the relevant documentation, to `values.yaml`.

1. It’s difficult to infer that `controllers.main.containers.main.env` maps to the `env` of `immich-server` just from its name. This is probably a limitation of `bjw-s.common.loader.all`, but as far as I know, Immich is the only chart currently using it.

2. For legacy chart users migrating their database settings, there is insufficient explanation of **where** to move those values. While the existing comments indicate the location, it still remains unclear **which keys and values** are valid and how they should be configured.

When migrating from chart version **0.9.x to 0.10.x**, I used the following methods to investigate the database configuration values:

* **Checked `./charts/immich/templates/server.yaml`** to see where the `env` variables are defined.
  → Failed: the expansion is hidden by `bjw-s.common.loader.all`, and I couldn’t determine how it worked.

* **Looked for information in the official documentation.**
  → Failed: there was no explanation about these settings.

Ultimately, I found **Issue #258** and relied on the actual configuration file shared by user **kryoseu**, which allowed me to configure it successfully.
https://github.com/immich-app/immich-charts/issues/258#issuecomment-3393490928

The task of migrating the database connection settings took significantly more time than expected.
With this PR, the configuration process for the database should become much clearer.