### PR TITLE
Add serviceName to main serviceMonitor configuration

### DIFF
--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -86,6 +86,7 @@ service:
 serviceMonitor:
   main:
     enabled: {{ .Values.immich.metrics.enabled }}
+    serviceName: main
     endpoints:
       - port: metrics-api
         scheme: http


### PR DESCRIPTION
Without this is pretty hard to add additional containers if you are using a ServiceMonitor, it will complain with something like this:
```
helm.go:84: [debug] execution error at (immich/charts/immich/templates/server.yaml:111:4): Either service.name or service.identifier is required because automatic Service detection is not possible. (serviceMonitor: main)
```