### PR TITLE
feat: Add PTSC config for helmchart

### DIFF
--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -12,6 +12,11 @@ controllers:
   main:
     type: deployment
     strategy: RollingUpdate
+    pod:
+      {{- with .Values.server.controllers.main.pod.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     containers:
       main:
         env:

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -63,6 +63,17 @@ server:
   enabled: true
   controllers:
     main:
+      pod:
+        # Example topologySpreadConstraints configuration:
+        # topologySpreadConstraints:
+        #   - maxSkew: 1
+        #     topologyKey: kubernetes.io/hostname
+        #     whenUnsatisfiable: DoNotSchedule
+        #     labelSelector:
+        #       matchLabels:
+        #         app.kubernetes.io/name: immich
+        #         app.kubernetes.io/component: server
+        topologySpreadConstraints: []
       containers:
         main:
           image:


### PR DESCRIPTION
# Add PodTopologySpreadConstraint support to server deployment

Added support for configuring PodTopologySpreadConstraints on the server component to enable better pod distribution across topology domains (e.g., nodes, zones).

Changes:

Updated [server.yaml](vscode-file://vscode-app/c:/Users/bovel/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to render topologySpreadConstraints at the pod level
Added topologySpreadConstraints field to server.controllers.main.pod in [values.yaml](vscode-file://vscode-app/c:/Users/bovel/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with example configuration
Defaults to empty array (no constraints) for backward compatibility