### PR TITLE
add optional Valkey password auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,18 @@ There are a few things that you are required to configure in your values.yaml be
 The immich chart is highly customizable. You can see a detailed documentation
 of all possible changes within the `charts/immich/values.yaml` file. Anything not covered there can be done by making direct use of the underlying common library chart (see below).
 
-## Chart architecture 
+## Chart architecture
 
 This chart uses the [common library](https://github.com/bjw-s-labs/helm-charts/tree/common-4.3.0/charts/library/common). Top level keys like `controllers` are applied to every component of the Immich stack, and the entries under the `server`, `microservices`, etc... keys define the specific values for each component. You can freely add more top level keys to be applied to all the components, please reference [the common library's values.yaml](https://github.com/bjw-s-labs/helm-charts/blob/common-4.3.0/charts/library/common/values.yaml) to see what keys are available.
+
+## Valkey authentication
+
+If Valkey is enabled, it is recommended to enable authentication by setting `immich.valkey.auth.enabled` to `true`.
+
+There are two modes for managing the authentication secret:
+
+* Auto-generated secret: If `immich.valkey.auth.existingSecret` is not defined, the chart will automatically generate a secure password and store it in a secret named `<release-name>-valkey-auth`. Helm upgrade does not change the password.
+* If `immich.valkey.auth.existingSecret` is defined, then you must create a kubernetes secret with a `REDIS_PASSWORD` key.
 
 ## Uninstalling the Chart
 

--- a/charts/immich/templates/_helpers.tpl
+++ b/charts/immich/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{- define "valkey.secretName" -}}
+    {{- if .Values.immich.valkey.auth.existingSecret }}{{ .Values.immich.valkey.auth.existingSecret }}{{ else }}{{ printf "%s-valkey-auth" .Release.Name }}{{ end }}
+{{- end -}}
+
+{{- define "valkey.password" -}}
+    {{- $secretName := include "valkey.secretName" .  -}}
+    {{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+    {{- if .Values.immich.valkey.auth.existingSecret -}}
+        {{- if not $secret -}}
+            {{- fail (printf "existing secret %s not found in namespace %s" $secretName .Release.Namespace) -}}
+        {{- else if not $secret.data.REDIS_PASSWORD -}}
+            {{- fail (printf "existing secret %s found but data.REDIS_PASSWORD is missing or empty" $secretName) -}}
+        {{- end -}}
+    {{- end -}}
+    {{- if $secret -}}
+        {{- $secret.data.REDIS_PASSWORD | b64dec -}}
+    {{- else -}}
+        {{- randAlphaNum 40 -}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "valkey.secretChecksum" -}}
+    {{- $password := include "valkey.password" . -}}
+    {{- $data := dict "REDIS_PASSWORD" ($password | b64enc) -}}
+    {{- $data | toJson | sha256sum -}}
+{{- end -}}

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -2,11 +2,14 @@
 global:
   nameOverride: server
 
-{{- if .Values.immich.configuration }}
 defaultPodOptions:
   annotations:
+    {{- if .Values.immich.configuration }}
     checksum/config: {{ .Values.immich.configuration | toYaml | sha256sum }}
-{{- end }}
+    {{- end }}
+    {{- if .Values.immich.valkey.auth.enabled }}
+    checksum/valkey-auth: {{ include "valkey.secretChecksum" . }}
+    {{- end }}
 
 controllers:
   main:
@@ -14,6 +17,11 @@ controllers:
     strategy: RollingUpdate
     containers:
       main:
+        {{- if .Values.immich.valkey.auth.enabled }}
+        envFrom:
+          - secretRef:
+              name: {{ include "valkey.secretName" . }}
+        {{- end }}
         env:
           {{ if .Values.immich.metrics.enabled }}
           IMMICH_TELEMETRY_INCLUDE: all

--- a/charts/immich/templates/valkey-auth-secret.yaml
+++ b/charts/immich/templates/valkey-auth-secret.yaml
@@ -1,0 +1,9 @@
+{{- if and (.Values.immich.valkey.auth.enabled) (not .Values.immich.valkey.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-valkey-auth" .Release.Name }}
+type: Opaque
+data:
+  REDIS_PASSWORD: {{ include "valkey.password" . | b64enc }}
+{{- end }}

--- a/charts/immich/templates/valkey.yaml
+++ b/charts/immich/templates/valkey.yaml
@@ -6,8 +6,20 @@ controllers:
   main:
     type: deployment
     strategy: Recreate
+    {{- if .Values.immich.valkey.auth.enabled }}
+    podAnnotations:
+      checksum/valkey-auth: {{ include "valkey.secretChecksum" . }}
+    {{- end }}
     containers:
       main:
+        {{- if .Values.immich.valkey.auth.enabled }}
+        envFrom:
+          - secretRef:
+              name: {{ if .Values.immich.valkey.auth.existingSecret }}{{ .Values.immich.valkey.auth.existingSecret }}{{ else }}{{ printf "%s-valkey-auth" .Release.Name }}{{ end }}
+        args:
+          - --requirepass
+          - $(REDIS_PASSWORD)
+        {{- end }}
         ports:
           - name: redis
             containerPort: 6379
@@ -21,7 +33,7 @@ controllers:
                 command:
                   - sh
                   - -c
-                  - "valkey-cli ping | grep PONG"
+                  - REDISCLI_AUTH="$REDIS_PASSWORD" valkey-cli ping | grep PONG
               initialDelaySeconds: 30
               periodSeconds: 10
               timeoutSeconds: 5
@@ -34,7 +46,7 @@ controllers:
                 command:
                   - sh
                   - -c
-                  - "valkey-cli ping | grep PONG"
+                  - REDISCLI_AUTH="$REDIS_PASSWORD" valkey-cli ping | grep PONG
               initialDelaySeconds: 5
               periodSeconds: 10
               timeoutSeconds: 5
@@ -47,7 +59,7 @@ controllers:
                 command:
                   - sh
                   - -c
-                  - "valkey-cli ping | grep PONG"
+                  - REDISCLI_AUTH="$REDIS_PASSWORD" valkey-cli ping | grep PONG
               initialDelaySeconds: 0
               periodSeconds: 10
               timeoutSeconds: 5

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -35,6 +35,12 @@ immich:
     # storageTemplate:
     #   enabled: true
     #   template: "{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}"
+  valkey:
+    auth:
+      # Optional: enable Valkey password authentication.
+      enabled: false
+      # If defined, a kubernetes secret with REDIS_PASSWORD key must be created before installing the chart.
+      existingSecret: ""
 
 # Dependencies
 


### PR DESCRIPTION
Previously, Redis dependency chart had random password authentication. The new Valkey deployment does not enable password auth or kubernetes network policy.

This PR restores password auth for Valkey. The new `immich.valkey.auth.enabled` option is `false` by default, but the readme is extended with recommendation to enable it.