### PR TITLE
refactor: add option to store configuration in a secret

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A chart to power Immich (immich.app) running on kubernetes
 name: immich
-version: 0.10.4
+version: 0.10.3
 appVersion: v2.0.0
 home: https://immich.app/
 icon: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.svg

--- a/charts/immich/templates/checks.yaml
+++ b/charts/immich/templates/checks.yaml
@@ -8,3 +8,7 @@
 {{ if hasKey .Values "redis" }}
     {{ fail "The redis subchart has been removed. Please see https://github.com/immich-app/immich-charts/releases/tag/immich-0.10.0 for more detail."}}
 {{ end }}
+
+{{- if and (ne .Values.immich.configurationKind "Secret") (ne .Values.immich.configurationKind "ConfigMap") }}
+    {{- fail "Invalid immich.configurationKind: must be either 'ConfigMap' or 'Secret'" }}
+{{- end }}

--- a/charts/immich/templates/immich-config.yml
+++ b/charts/immich/templates/immich-config.yml
@@ -1,10 +1,6 @@
 {{- if .Values.immich.configuration }}
 apiVersion: v1
-{{- if .Values.immich.storeConfigInSecret }}
-kind: Secret
-{{- else }}
-kind: ConfigMap
-{{- end }}
+kind: {{ .Values.immich.configurationKind }}
 metadata:
   name: {{ .Release.Name }}-immich-config
   labels:
@@ -13,7 +9,7 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: {{ printf "%s-%s\n" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- if .Values.immich.storeConfigInSecret }}
+{{- if (eq .Values.immich.configurationKind "Secret")}}
 type: Opaque
 stringData:
 {{- else }}

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -96,7 +96,7 @@ persistence:
 {{- if .Values.immich.configuration }}
   config:
     enabled: true
-    {{- if .Values.immich.storeConfigInSecret }}
+    {{- if eq .Values.immich.configurationKind "Secret" }}
     type: secret
     {{- else }}
     type: configMap

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -35,8 +35,8 @@ immich:
     # storageTemplate:
     #   enabled: true
     #   template: "{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}"
-  # Enabling this will store the immich configuration in a kubernetes secret instead of a configmap
-  storeConfigInSecret: false
+  # Sets the resource Kind to store configuration in. Must be either ConfigMap or Secret.
+  configurationKind: ConfigMap
 
 # Dependencies
 


### PR DESCRIPTION
Hello, 
I love this project and have been using it a lot. I wanted to contribute a bit and thought this small commit is a good place to start.

This pull request adds support for optionally storing the Immich configuration in a Kubernetes Secret instead of a ConfigMap, improving security for sensitive configurations. The change is controlled by a new `storeConfigInSecret` value. The chart version has also been bumped to reflect this enhancement.

**Support for storing configuration in a Secret:**

* Added logic in `immich-config.yml` to create either a Secret or ConfigMap based on the `immich.storeConfigInSecret` value, including handling of `type` and data fields accordingly. [[1]](diffhunk://#diff-59a827c7873f36abf5761214065b3ac2f0dc909a83ff895777e25833a197e7edR3-R7) [[2]](diffhunk://#diff-59a827c7873f36abf5761214065b3ac2f0dc909a83ff895777e25833a197e7edR16-R21)
* Updated `server.yaml` to mount the configuration as either a secret or configMap, depending on the same value.
* Introduced the `storeConfigInSecret` option in `values.yaml` with a default of `false` and documentation.
* Default functionality is to still create a configMap for backwards compatibility, However I recommend enabling this feature by default in a future release.

**Chart version update:**

* Bumped the chart version from `0.10.3` to `0.10.4` in `Chart.yaml` to reflect the new feature.