### PR TITLE
feat(config): add option to use an existing config not managed by the chart

### DIFF
--- a/charts/immich/templates/immich-config.yml
+++ b/charts/immich/templates/immich-config.yml
@@ -1,4 +1,7 @@
-{{- if and .Values.immich.configuration (not .Values.immich.existingConfigurationName) }}
+{{- if and .Values.immich.configuration .Values.immich.existingConfiguration }}
+{{- fail "immich.configuration and immich.existingConfiguration are mutually exclusive." }}
+{{- end }}
+{{- if and .Values.immich.configuration (not .Values.immich.existingConfiguration) }}
 apiVersion: v1
 kind: {{ .Values.immich.configurationKind }}
 metadata:

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -18,7 +18,7 @@ controllers:
           {{ if .Values.immich.metrics.enabled }}
           IMMICH_TELEMETRY_INCLUDE: all
           {{ end }}
-          {{- if .Values.immich.configuration }}
+          {{- if or .Values.immich.configuration .Values.immich.existingConfiguration }}
           IMMICH_CONFIG_FILE: /config/immich-config.yaml
           {{- end }}
         ports:
@@ -93,7 +93,7 @@ serviceMonitor:
         scheme: http
 
 persistence:
-{{- if or .Values.immich.configuration .Values.immich.existingConfigurationName }}
+{{- if or .Values.immich.configuration .Values.immich.existingConfiguration }}
   config:
     enabled: true
     {{- if eq .Values.immich.configurationKind "Secret" }}
@@ -101,8 +101,8 @@ persistence:
     {{- else }}
     type: configMap
     {{- end }}
-    {{- if .Values.immich.existingConfigurationName }}
-    name: {{ .Values.immich.existingConfigurationName }}
+    {{- if .Values.immich.existingConfiguration }}
+    name: {{ .Values.immich.existingConfiguration }}
     {{- else }}
     name: {{ .Release.Name }}-immich-config
     {{- end }}

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -25,7 +25,7 @@ immich:
       # Automatically creating the library volume is not supported by this chart
       # You have to specify an existing PVC to use
       existingClaim:
-  # configuration is immich-config.json converted to yaml. Ignored if existingConfigurationName is set.
+  # configuration is immich-config.json converted to yaml. Ignored if existingConfiguration is set.
   # ref: https://immich.app/docs/install/config-file/
   #
   configuration: {}
@@ -39,7 +39,7 @@ immich:
   configurationKind: ConfigMap
 
   # Specify existing configuration resource name here to skip creation of a new one
-  existingConfigurationName: ""
+  # existingConfiguration:
 
 # Dependencies
 


### PR DESCRIPTION
This pull request updates the Immich Helm chart to support using an existing configuration resource (either a ConfigMap or Secret) instead of always creating a new one. The changes allow users to specify the name of an existing configuration resource, which is then used by the chart, and ensures that configuration creation is skipped when this option is set.

Configuration management improvements:

* Added support for specifying an existing configuration resource via the new `immich.existingConfigurationName` value in `values.yaml`, allowing users to skip creation of a new ConfigMap or Secret.
* Updated the logic in `immich-config.yml` to only create a new configuration resource if `immich.configuration` is set and `immich.existingConfigurationName` is not set.
* Modified the persistence configuration in `server.yaml` to use the existing configuration resource name if specified, otherwise fall back to the default generated name.
* Clarified in `values.yaml` that the `configuration` field is ignored if `existingConfigurationName` is set, improving documentation for chart users.