### PR TITLE
feat: added configurable updateStrategy to server deployment

### DIFF
--- a/charts/immich/templates/checks.yaml
+++ b/charts/immich/templates/checks.yaml
@@ -12,3 +12,13 @@
 {{- if and (ne .Values.immich.configurationKind "Secret") (ne .Values.immich.configurationKind "ConfigMap") }}
     {{- fail "Invalid immich.configurationKind: must be either 'ConfigMap' or 'Secret'" }}
 {{- end }}
+
+# Validate server.updateStrategy
+{{- $serverUpdateStrategy := .Values.server.updateStrategy | default "RollingUpdate" -}}
+{{- if not (kindIs "string" $serverUpdateStrategy) -}}
+  {{- fail (printf "server.updateStrategy must be a string (got %serverUpdateStrategy)" (kindOf $serverUpdateStrategy)) -}}
+{{- end -}}
+
+{{- if not (has $serverUpdateStrategy (list "RollingUpdate" "Recreate")) -}}
+  {{- fail (printf "server.updateStrategy must be either RollingUpdate or Recreate (got %q)" $serverUpdateStrategy) -}}
+{{- end -}}

--- a/charts/immich/templates/server.yaml
+++ b/charts/immich/templates/server.yaml
@@ -11,7 +11,7 @@ defaultPodOptions:
 controllers:
   main:
     type: deployment
-    strategy: RollingUpdate
+    strategy: {{ .Values.server.updateStrategy }}
     containers:
       main:
         env:

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -70,6 +70,7 @@ server:
           image:
             repository: ghcr.io/immich-app/immich-server
             pullPolicy: IfNotPresent
+  updateStrategy: RollingUpdate
   ingress:
     main:
       enabled: false


### PR DESCRIPTION
This enables setting the spec.strategy to Recreate on the server deployment. This includes checks in the checks.yaml to have some nice UX.
Without this, having a storage backend that does not allow for a multiattached pv the current chart always results in manual intervention (manual deletion of the old pod or restarting the entire deployment).