### PR TITLE
feat: add admin bootstrap job template

### DIFF
--- a/charts/immich/templates/admin-bootstrap-job.yaml
+++ b/charts/immich/templates/admin-bootstrap-job.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.immich.bootstrap.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-immich-admin-bootstrap
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.immich.bootstrap.backoffLimit | default 3 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ .Chart.Name }}-admin-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          image: {{ printf "%s:%s" .Values.immich.bootstrap.image.repository (.Values.immich.bootstrap.image.tag | toString) | quote }}
+          imagePullPolicy: {{ .Values.immich.bootstrap.image.pullPolicy | default "IfNotPresent" }}
+          {{- with .Values.immich.bootstrap.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.immich.bootstrap.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- if eq .Values.immich.bootstrap.bootstrapKind "Secret" }}
+            - name: ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required ".Values.immich.bootstrap.existingSecret is required when bootstrapKind is Secret" .Values.immich.bootstrap.existingSecret }}
+                  key: {{ .Values.immich.bootstrap.existingSecretKeys.email | default "email" }}
+            - name: ADMIN_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.immich.bootstrap.existingSecret }}
+                  key: {{ .Values.immich.bootstrap.existingSecretKeys.name | default "name" }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.immich.bootstrap.existingSecret }}
+                  key: {{ .Values.immich.bootstrap.existingSecretKeys.password | default "password" }}
+            {{- else }}
+            - name: ADMIN_EMAIL
+              value: {{ required ".Values.immich.bootstrap.adminEmail is required" .Values.immich.bootstrap.adminEmail | quote }}
+            - name: ADMIN_NAME
+              value: {{ .Values.immich.bootstrap.adminName | default "Immich Admin" | quote }}
+            - name: ADMIN_PASSWORD
+              value: {{ required ".Values.immich.bootstrap.defaultPassword is required" .Values.immich.bootstrap.defaultPassword | quote }}
+            {{- end }}
+          command:
+            - sh
+            - -c
+            - |
+              API_URL="{{ .Values.immich.bootstrap.apiUrl | default (printf "http://%s-server:2283" .Release.Name) }}"
+              json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+              echo "Waiting for Immich API..."
+              RETRIES=0
+              until curl -sf \
+                {{- if .Values.immich.bootstrap.hostHeader }}
+                -H "Host: {{ .Values.immich.bootstrap.hostHeader }}" \
+                {{- end }}
+                "${API_URL}/api/server/ping" > /dev/null; do
+                RETRIES=$((RETRIES + 1))
+                if [ "$RETRIES" -ge 60 ]; then
+                  echo "Timed out waiting for Immich API after 300 seconds."
+                  exit 1
+                fi
+                sleep 5
+              done
+              echo "Creating admin account..."
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                -X POST \
+                {{- if .Values.immich.bootstrap.hostHeader }}
+                -H "Host: {{ .Values.immich.bootstrap.hostHeader }}" \
+                {{- end }}
+                -H "Content-Type: application/json" \
+                "${API_URL}/api/auth/admin-sign-up" \
+                -d "{
+                  \"email\": \"$(json_escape "$ADMIN_EMAIL")\",
+                  \"name\": \"$(json_escape "$ADMIN_NAME")\",
+                  \"password\": \"$(json_escape "$ADMIN_PASSWORD")\"
+                }")
+              if [ "$STATUS" = "201" ]; then
+                echo "Admin account created successfully."
+              elif [ "$STATUS" = "400" ]; then
+                echo "Admin account already exists, skipping."
+                exit 0
+              else
+                echo "Unexpected response: $STATUS"
+                exit 1
+              fi
+{{- end }}

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -16,6 +16,72 @@ controllers:
           # Add the env vars to connect to your database here.
 
 immich:
+
+  bootstrap:
+    # Set to true to create the admin account on first install (Helm post-install hook)
+    enabled: false
+
+    # Container image for the bootstrap job
+    # Pinned to a specific version for reproducibility — change tag to upgrade
+    image:
+      repository: curlimages/curl
+      tag: "8.12.1"
+      pullPolicy: IfNotPresent
+
+    # Security context for the bootstrap container
+    # curlimages/curl runs as UID 100 (curl_user) — no root needed
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 100
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
+    # Resource requests and limits for the bootstrap container
+    resources: {}
+    # resources:
+    #   requests:
+    #     cpu: 10m
+    #     memory: 32Mi
+    #   limits:
+    #     memory: 64Mi
+
+    # Number of retries before the Job is considered failed (Kubernetes default: 6)
+    backoffLimit: 3
+
+    # Admin credentials — used when bootstrapKind is not "Secret"
+    adminEmail: ""
+    adminName: "Immich Admin"
+    defaultPassword: ""
+
+    # Set to "Secret" to read admin credentials from an existing Kubernetes Secret.
+    # Recommended for production to avoid storing passwords in values files.
+    # Example Secret:
+    #   kubectl create secret generic immich-admin \
+    #     --from-literal=email=admin@example.com \
+    #     --from-literal=name="Immich Admin" \
+    #     --from-literal=password=changeme
+    bootstrapKind: ""
+    # Name of the existing Secret (required when bootstrapKind is "Secret")
+    existingSecret: ""
+    # Keys to read from the Secret
+    existingSecretKeys:
+      email: email
+      name: name
+      password: password
+
+    # Override the Immich API URL used during bootstrap.
+    # Defaults to the internal Kubernetes service: http://<release-name>-server:2283
+    # Useful when the server is only reachable via an external URL or a proxy.
+    # Example: http://my-proxy.svc.cluster.local:8080
+    apiUrl: ""
+    # Optional Host header added to every curl request.
+    # Required when routing through a proxy that uses the Host header for routing.
+    # Example: immich.example.com
+    hostHeader: ""
+
   metrics:
     # Enabling this will create the service monitors needed to monitor immich with the prometheus operator
     enabled: false


### PR DESCRIPTION
After a fresh Immich install you still need to manually hit the UI to
create the admin account before anything works. This PR automates that
step with an optional post-install Job.

When `immich.bootstrap.enabled: true`, a small curl container runs after
the chart is installed, waits for the server to be ready, and calls
`/api/auth/admin-sign-up`. If the admin already exists it skips silently,
so it's safe to leave enabled.

Credentials can be passed inline (fine for local dev) or pulled from an
existing Secret (recommended for prod):

```yaml
immich:
  bootstrap:
    enabled: true
    bootstrapKind: Secret
    existingSecret: immich-admin  # keys: email, name, password
```

Tested on kind, happy path creates the account, re-run with an existing
admin exits cleanly.

Closes #361 