### PR TITLE
fix: immich ML container stays unhealthy

### DIFF
--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -100,6 +100,7 @@ machine-learning:
             TRANSFORMERS_CACHE: /cache
             HF_XET_CACHE: /cache/huggingface-xet
             MPLCONFIGDIR: /cache/matplotlib-config
+            GUNICORN_CMD_ARGS: "--no-control-socket"
   persistence:
     cache:
       enabled: true


### PR DESCRIPTION
This is taken from: https://github.com/immich-app/immich/issues/27228

The machine-learning container will otherwise always be unhealthy