### PR TITLE
feat: package README and changelog into the chart for ArtifactHub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,24 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Package README into chart
+        run: cp README.md charts/immich/README.md
+
+      - name: Inject changelog into chart annotations
+        env:
+          NOTES: ${{ github.event.release.body }}
+        run: |
+          changes=$(printf '%s\n' "$NOTES" \
+            | mdq --output plain '-' \
+            | sed -E 's/ \([0-9a-f]{7,40}\)//g; /^[[:space:]]*$/d; s/^/- /' \
+            | awk '!seen[$0]++' || true)
+          if [ -n "$changes" ]; then
+            export changes
+            yq -i '.annotations."artifacthub.io/changes" = strenv(changes)' charts/immich/Chart.yaml
+          else
+            echo "No changelog entries parsed from release notes; leaving annotations unchanged."
+          fi
+
       - name: build chart dependencies
         run: helm dependency build charts/immich
 

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -18,6 +18,3 @@ dependencies:
     version: 5.0.1
 annotations:
   artifacthub.io/category: storage
-  artifacthub.io/changes: |-
-    - kind: changed
-      description: Dependency updates

--- a/mise.lock
+++ b/mise.lock
@@ -147,3 +147,34 @@ url = "https://github.com/tilt-dev/tilt/releases/download/v0.37.4/tilt.0.37.4.ma
 [tools.tilt."platforms.windows-x64"]
 checksum = "sha256:41d38b2ecd569e9b0ec73bc7d753fdb67bd24fcf1e434610b72d59c9a22c3041"
 url = "https://github.com/tilt-dev/tilt/releases/download/v0.37.4/tilt.0.37.4.windows.x86_64.zip"
+
+[[tools."ubi:yshavit/mdq"]]
+version = "0.10.0"
+backend = "ubi:yshavit/mdq"
+
+[tools."ubi:yshavit/mdq"."platforms.linux-x64-mdq"]
+checksum = "blake3:2fd08f2aa79354a7fb6aa1fa97bc7a742b9d9432fb63c659a857b9787050e4a6"
+
+[[tools.yq]]
+version = "4.53.3"
+backend = "aqua:mikefarah/yq"
+
+[tools.yq."platforms.linux-arm64"]
+checksum = "sha256:578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_arm64"
+
+[tools.yq."platforms.linux-x64"]
+checksum = "sha256:fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64"
+
+[tools.yq."platforms.macos-arm64"]
+checksum = "sha256:877de31753a4dd2401aa048937aa9a7fc4d5f6ce858cf31508c5802954297213"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_darwin_arm64"
+
+[tools.yq."platforms.macos-x64"]
+checksum = "sha256:b4ba1ecce3c47f00803f4f964de38394326c7a32eb6540616e04fb2935a0f08d"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_darwin_amd64"
+
+[tools.yq."platforms.windows-x64"]
+checksum = "sha256:e279bc506a452eeafcdf364f91a025455e402a8001169083caf01f4b64a544e2"
+url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_windows_amd64.exe"

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,8 @@ kind = "0.32.0"
 kubectl = "1.36.2"
 oras = "1.3.2"
 tilt = "0.37.4"
+"ubi:yshavit/mdq" = "0.10.0"
+yq = "4.53.3"
 
 [env]
 HELM_PLUGINS = { value = "{{ tools | get(key='asdf:dex4er/asdf-helm-diff') | get(key='path') }}", tools = true }


### PR DESCRIPTION
ArtifactHub only shows a README/changelog if they're **in the packaged chart** — the README from the chart dir, and the changelog from the `artifacthub.io/changes` annotation (it does not read `CHANGELOG.md` or GitHub releases). Both are added at publish time so the source tree stays clean.

## Changes

- **README** — `cp README.md charts/immich/README.md` before `helm package`, so ArtifactHub renders it.
- **Changelog** — extract entries from the release-please notes (`github.event.release.body`) with [`mdq`](https://github.com/yshavit/mdq) and inject them into `artifacthub.io/changes` (simple-list) via `yq`, before packaging. `mdq --output plain '-'` does the structural list selection and strips bold + link URLs; a small `sed` drops the trailing commit-sha refs (keeping `(#PR)`). **Guarded and non-fatal** (`|| true` + empty check) — `mdq` exits non-zero on no matches, so a parse miss just skips the annotation instead of failing the release.
- Dropped the vestigial static `artifacthub.io/changes` from `Chart.yaml`; pinned `mdq` (ubi backend) and `yq` in `mise.toml`.

## Verified locally

Ran the full `mdq | sed | yq` pipeline against a realistic release-please body (breaking + features + scoped deps):

```yaml
artifacthub.io/changes: |-
  - the github.io HTTP repo is removed; use the OCI registry
  - publish via release-please to OCI (#377)
  - deps: bump common to v5.1.0 (#380)
```

Empty-input case confirmed to skip cleanly.

## Notes

- Simple-list format; the structured form (`kind:` + PR links) renders nicer but needs section→kind parsing — easy follow-up.
- Publish-time only: a local `helm package` won't include these (same trade-off as any CI enrichment).