### PR TITLE
fix: quote changelog entries in artifacthub.io/changes annotation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,11 +32,13 @@ jobs:
         env:
           NOTES: ${{ github.event.release.body }}
         run: |
-          changes=$(printf '%s\n' "$NOTES" \
+          descs=$(printf '%s\n' "$NOTES" \
             | mdq --output plain '-' \
-            | sed -E 's/ \([0-9a-f]{7,40}\)//g; /^[[:space:]]*$/d; s/^/- /' \
+            | sed -E 's/ \([0-9a-f]{7,40}\)//g; /^[[:space:]]*$/d' \
             | awk '!seen[$0]++' || true)
-          if [ -n "$changes" ]; then
+          if [ -n "$descs" ]; then
+            export descs
+            changes=$(yq -n -o=yaml 'strenv(descs) | split("\n") | map(select(. != "")) | .[] style="double"')
             export changes
             yq -i '.annotations."artifacthub.io/changes" = strenv(changes)' charts/immich/Chart.yaml
           else


### PR DESCRIPTION
0.13.0 failed to ingest on ArtifactHub:

> invalid changes annotation. Please use quotes on strings that include any of the following characters: `{}:[],&*#?|-<>=!%@`

The injected `artifacthub.io/changes` list had **unquoted** items, so entries with YAML-special chars broke parsing — most notably a leading scope like `- ci: scope release-please to the whole repo (#378)` parses as a **map** (`{ci: ...}`), not a string.

Result (verified against the real 0.13.0 release body):

```yaml
artifacthub.io/changes: |-
  - "values schema (#382)"
  - "publish via release-please to OCI (#377)"
  - "package README and changelog into the chart for ArtifactHub (#379)"
  - "sign Helm chart with cosign on release (#332)"
  - "ci: scope release-please to the whole repo (#378)"
  - "update http-repo deprecation notice (#381)"
```
